### PR TITLE
Updated dynamodb gateway to order result by sort key

### DIFF
--- a/environment/deploy-common-infrastructure.sh
+++ b/environment/deploy-common-infrastructure.sh
@@ -7,9 +7,11 @@ if [[ -z $(awslocal dynamodb list-tables | grep audit-log) ]]; then
   awslocal dynamodb create-table \
     --table-name audit-log \
     --attribute-definitions \
-      AttributeName=messageId,AttributeType=S \
+      AttributeName=messageId,AttributeType=S AttributeName=_,AttributeType=S AttributeName=receivedDate,AttributeType=S \
     --key-schema \
       AttributeName=messageId,KeyType=HASH \
     --provisioned-throughput \
-      ReadCapacityUnits=10,WriteCapacityUnits=5
+      ReadCapacityUnits=10,WriteCapacityUnits=5 \
+    --global-secondary-index \
+      IndexName=receivedDateIndex,KeySchema=\[\{AttributeName=_,KeyType=HASH\},\{AttributeName=receivedDate,KeyType=RANGE\}\],ProvisionedThroughput=\{ReadCapacityUnits=10,WriteCapacityUnits=5\},Projection=\{ProjectionType=ALL\}
 fi

--- a/shared/src/AuditLogDynamoGateway/AuditLogDynamoGateway.ts
+++ b/shared/src/AuditLogDynamoGateway/AuditLogDynamoGateway.ts
@@ -6,6 +6,8 @@ import AuditLog from "../AuditLog"
 export default class AuditLogDynamoGateway extends DynamoGateway {
   private readonly tableKey: string = "messageId"
 
+  private readonly sortKey: string = "receivedDate"
+
   constructor(config: DynamoDbConfig, private readonly tableName: string) {
     super(config)
   }
@@ -21,7 +23,7 @@ export default class AuditLogDynamoGateway extends DynamoGateway {
   }
 
   async fetchMany(limit = 10): PromiseResult<AuditLog[]> {
-    const result = await this.getMany(this.tableName, limit)
+    const result = await this.getMany(this.tableName, this.sortKey, limit)
 
     if (isError(result)) {
       return result

--- a/shared/src/DynamoGateway/TestDynamoGateway.ts
+++ b/shared/src/DynamoGateway/TestDynamoGateway.ts
@@ -11,7 +11,12 @@ export default class TestDynamoGateway extends DynamoGateway {
     return !!tableResult.TableNames?.find((name) => name === tableName)
   }
 
-  async createTable(tableName: string, keyName: string, skipIfExists = true): Promise<CreateTableOutput | undefined> {
+  async createTable(
+    tableName: string,
+    keyName: string,
+    sortKey: string,
+    skipIfExists = true
+  ): Promise<CreateTableOutput | undefined> {
     if (skipIfExists && (await this.tableExists(tableName))) {
       return undefined
     }
@@ -22,12 +27,42 @@ export default class TestDynamoGateway extends DynamoGateway {
           {
             AttributeName: keyName,
             AttributeType: "S"
+          },
+          {
+            AttributeName: sortKey,
+            AttributeType: "S"
+          },
+          {
+            AttributeName: "_",
+            AttributeType: "S"
           }
         ],
         KeySchema: [
           {
             AttributeName: keyName,
             KeyType: "HASH"
+          }
+        ],
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: `${sortKey}Index`,
+            KeySchema: [
+              {
+                AttributeName: "_",
+                KeyType: "HASH"
+              },
+              {
+                AttributeName: sortKey,
+                KeyType: "RANGE"
+              }
+            ],
+            Projection: {
+              ProjectionType: "ALL"
+            },
+            ProvisionedThroughput: {
+              ReadCapacityUnits: 1,
+              WriteCapacityUnits: 1
+            }
           }
         ],
         ProvisionedThroughput: {


### PR DESCRIPTION
Added a global secondary index to `audit-log` table.

DynamoDb can only sort the results by the range key, however, the primary key must exist in the `KeyConditionExpression` of the query. Since the primary key is `messageId`, we cannot use that to get all the records.

As a workaround, a dummy primary key added to the GSI (Global Secondary Index) to be able to sort results by date.
This dummy key has a fixed value so the condition in `KeyConditionExpression` will be always true for all records.