### PR TITLE
Added eventSourceQueueName to BichardAuditLogEvent

### DIFF
--- a/shared/src/types/BichardAuditLogEvent.ts
+++ b/shared/src/types/BichardAuditLogEvent.ts
@@ -6,9 +6,12 @@ export default class BichardAuditLogEvent extends AuditLogEvent {
 
   public readonly eventSourceArn: string
 
-  constructor({ eventSourceArn, s3Path, ...options }: BichardAuditLogEventOptions) {
+  public readonly eventSourceQueueName: string
+
+  constructor({ eventSourceQueueName, eventSourceArn, s3Path, ...options }: BichardAuditLogEventOptions) {
     super(options)
 
+    this.eventSourceQueueName = eventSourceQueueName
     this.eventSourceArn = eventSourceArn
     this.s3Path = s3Path
   }

--- a/shared/src/types/BichardAuditLogEventOptions.ts
+++ b/shared/src/types/BichardAuditLogEventOptions.ts
@@ -3,4 +3,5 @@ import type AuditLogEventOptions from "./AuditLogEventOptions"
 export default interface BichardAuditLogEventOptions extends AuditLogEventOptions {
   s3Path: string
   eventSourceArn: string
+  eventSourceQueueName: string
 }

--- a/shared/src/types/EventMessage.ts
+++ b/shared/src/types/EventMessage.ts
@@ -4,4 +4,5 @@ export default interface EventMessage {
   messageData: string
   messageFormat: MessageFormat
   eventSourceArn: string
+  eventSourceQueueName: string
 }

--- a/shared/src/types/JmsTextMessage.ts
+++ b/shared/src/types/JmsTextMessage.ts
@@ -2,4 +2,7 @@ export default interface JmsTextMessage {
   messageID: string
   messageType: string
   data: string
+  destination: {
+    physicalName: string
+  }
 }

--- a/src/event-handler/e2e.test.ts
+++ b/src/event-handler/e2e.test.ts
@@ -55,17 +55,26 @@ test.each<string>(["audit-event", "general-event"])(
         {
           messageID: auditLog1.messageId,
           messageType: "messageType",
-          data: messageData1
+          data: messageData1,
+          destination: {
+            physicalName: ""
+          }
         },
         {
           messageID: auditLog1.messageId,
           messageType: "messageType",
-          data: messageData1
+          data: messageData1,
+          destination: {
+            physicalName: ""
+          }
         },
         {
           messageID: auditLog2.messageId,
           messageType: "messageType",
-          data: messageData2
+          data: messageData2,
+          destination: {
+            physicalName: ""
+          }
         }
       ]
     }

--- a/src/lambdas/message-receiver/src/e2e.test.ts
+++ b/src/lambdas/message-receiver/src/e2e.test.ts
@@ -12,7 +12,10 @@ test("given a message, the Step Function is invoked", async () => {
       {
         messageID: "",
         messageType: "",
-        data: ""
+        data: "",
+        destination: {
+          physicalName: ""
+        }
       }
     ]
   }

--- a/src/lambdas/message-receiver/src/embellishMessages.test.ts
+++ b/src/lambdas/message-receiver/src/embellishMessages.test.ts
@@ -5,13 +5,19 @@ test("returns all messages with message format attached", () => {
   const expectedMessage1: JmsTextMessage = {
     messageID: "",
     messageType: "",
-    data: "Message1"
+    data: "Message1",
+    destination: {
+      physicalName: "DUMMY_QUEUE_1"
+    }
   }
 
   const expectedMessage2: JmsTextMessage = {
     messageID: "",
     messageType: "",
-    data: "Message2"
+    data: "Message2",
+    destination: {
+      physicalName: "DUMMY_QUEUE_2"
+    }
   }
 
   const event: AmazonMqEventSourceRecordEvent = {
@@ -27,9 +33,37 @@ test("returns all messages with message format attached", () => {
   expect(actualMessage1.messageData).toBe(expectedMessage1.data)
   expect(actualMessage1.messageFormat).toBe("AuditEvent")
   expect(actualMessage1.eventSourceArn).toBe("DummyArn")
+  expect(actualMessage1.eventSourceQueueName).toBe("DUMMY_QUEUE_1")
 
   const actualMessage2 = messages[1]
   expect(actualMessage2.messageData).toBe(expectedMessage2.data)
   expect(actualMessage2.messageFormat).toBe("AuditEvent")
   expect(actualMessage2.eventSourceArn).toBe("DummyArn")
+  expect(actualMessage2.eventSourceQueueName).toBe("DUMMY_QUEUE_2")
+})
+
+test("returns corrected queue name when message is from failure queue", () => {
+  const expectedMessage: JmsTextMessage = {
+    messageID: "",
+    messageType: "",
+    data: "Message data",
+    destination: {
+      physicalName: "DUMMY_QUEUE.FAILURE"
+    }
+  }
+
+  const event: AmazonMqEventSourceRecordEvent = {
+    eventSource: "",
+    eventSourceArn: "DummyArn",
+    messages: [expectedMessage]
+  }
+
+  const { messages } = embellishMessages(event, "AuditEvent")
+  expect(messages).toHaveLength(1)
+
+  const actualMessage = messages[0]
+  expect(actualMessage.messageData).toBe(expectedMessage.data)
+  expect(actualMessage.messageFormat).toBe("AuditEvent")
+  expect(actualMessage.eventSourceArn).toBe("DummyArn")
+  expect(actualMessage.eventSourceQueueName).toBe("DUMMY_QUEUE")
 })

--- a/src/lambdas/message-receiver/src/embellishMessages.ts
+++ b/src/lambdas/message-receiver/src/embellishMessages.ts
@@ -1,7 +1,11 @@
-import type { EventMessage, MessageFormat, AmazonMqEventSourceRecordEvent } from "shared"
+import type { EventMessage, MessageFormat, AmazonMqEventSourceRecordEvent, JmsTextMessage } from "shared"
 
 type Result = {
   messages: EventMessage[]
+}
+
+const getEventSourceQueueName = (message: JmsTextMessage): string => {
+  return message.destination.physicalName.replace(".FAILURE", "")
 }
 
 export default (
@@ -11,6 +15,7 @@ export default (
   messages: messages.map((message) => ({
     messageData: message.data,
     messageFormat,
-    eventSourceArn
+    eventSourceArn,
+    eventSourceQueueName: getEventSourceQueueName(message)
   }))
 })

--- a/src/lambdas/record-event/src/e2e.test.ts
+++ b/src/lambdas/record-event/src/e2e.test.ts
@@ -31,7 +31,8 @@ describe("Record Event end-to-end", () => {
       eventType: "Test Event",
       timestamp: new Date(),
       eventSourceArn: "DummyArn",
-      s3Path: "DummyPath"
+      s3Path: "DummyPath",
+      eventSourceQueueName: "DummyQueue"
     })
 
     const input: RecordEventInput = {

--- a/src/lambdas/store-in-s3/src/StoreInS3UseCase.integration.test.ts
+++ b/src/lambdas/store-in-s3/src/StoreInS3UseCase.integration.test.ts
@@ -25,7 +25,8 @@ describe("StoreInS3UseCase", () => {
     const message: EventMessage = {
       messageData: "DummyXML",
       messageFormat: "AuditEvent",
-      eventSourceArn: "DummyArn"
+      eventSourceArn: "DummyArn",
+      eventSourceQueueName: "DummyQueueName"
     }
 
     const useCase = new StoreInS3UseCase(gateway)

--- a/src/lambdas/store-in-s3/src/e2e.test.ts
+++ b/src/lambdas/store-in-s3/src/e2e.test.ts
@@ -27,7 +27,8 @@ describe("Store in S3 end-to-end", () => {
     const message: EventMessage = {
       messageData: "DummyData",
       messageFormat: "AuditEvent",
-      eventSourceArn: "DummyArn"
+      eventSourceArn: "DummyArn",
+      eventSourceQueueName: "DummyQueueName"
     }
 
     const result = await invokeFunction<EventMessage, StoreInS3Result>("store-in-s3", message)

--- a/src/lambdas/translate-event/src/e2e.test.ts
+++ b/src/lambdas/translate-event/src/e2e.test.ts
@@ -22,7 +22,8 @@ const createPayload = (messageFormat: MessageFormat): TranslateEventInput => {
     messageData: encodeBase64(content),
     messageFormat,
     eventSourceArn: "DummyArn",
-    s3Path: "UNUSED"
+    s3Path: "UNUSED",
+    eventSourceQueueName: "DummyQueueName"
   }
 }
 
@@ -66,4 +67,5 @@ test.each<TestInput>([
   expect(event.timestamp).toBe(input.timestamp)
   expect(event.eventSourceArn).toBe(payload.eventSourceArn)
   expect(event.s3Path).toBe(payload.s3Path)
+  expect(event.eventSourceQueueName).toBe(payload.eventSourceQueueName)
 })

--- a/src/lambdas/translate-event/src/translators/AuditEventTranslator.test.ts
+++ b/src/lambdas/translate-event/src/translators/AuditEventTranslator.test.ts
@@ -11,7 +11,8 @@ test("parses the message data and returns an AuditLogEvent", async () => {
     messageData,
     s3Path: "DummyPath",
     eventSourceArn: "DummyArn",
-    messageFormat: "AuditEvent"
+    messageFormat: "AuditEvent",
+    eventSourceQueueName: "DummyQueueName"
   }
   const result = await AuditEventTranslator(eventInput)
 

--- a/src/lambdas/translate-event/src/translators/AuditEventTranslator.ts
+++ b/src/lambdas/translate-event/src/translators/AuditEventTranslator.ts
@@ -7,7 +7,7 @@ import type Translator from "./Translator"
 import transformEventDetails from "./transformEventDetails"
 
 const AuditEventTranslator: Translator = async (input: TranslateEventInput): PromiseResult<TranslationResult> => {
-  const { messageData, s3Path, eventSourceArn } = input
+  const { messageData, s3Path, eventSourceArn, eventSourceQueueName } = input
   // Audit events are in base64 encoded XML
   const xml = decodeBase64(messageData)
   const logItem = await parseXml<AuditEvent>(xml)
@@ -16,7 +16,7 @@ const AuditEventTranslator: Translator = async (input: TranslateEventInput): Pro
     return new Error("Failed to parse the Audit Event")
   }
 
-  const event = transformEventDetails(logItem.auditEvent, s3Path, eventSourceArn)
+  const event = transformEventDetails(logItem.auditEvent, s3Path, eventSourceArn, eventSourceQueueName)
   return {
     messageId: logItem.auditEvent.correlationID,
     event

--- a/src/lambdas/translate-event/src/translators/GeneralEventTranslator.test.ts
+++ b/src/lambdas/translate-event/src/translators/GeneralEventTranslator.test.ts
@@ -11,7 +11,8 @@ test("parses the message data and returns an AuditLogEvent", async () => {
     messageData,
     s3Path: "DummyPath",
     eventSourceArn: "DummyArn",
-    messageFormat: "AuditEvent"
+    messageFormat: "AuditEvent",
+    eventSourceQueueName: "DummyQueueName"
   }
   const result = await GeneralEventTranslator(eventInput)
 

--- a/src/lambdas/translate-event/src/translators/GeneralEventTranslator.ts
+++ b/src/lambdas/translate-event/src/translators/GeneralEventTranslator.ts
@@ -7,7 +7,7 @@ import type Translator from "./Translator"
 import transformEventDetails from "./transformEventDetails"
 
 const GeneralEventTranslator: Translator = async (input: TranslateEventInput): PromiseResult<TranslationResult> => {
-  const { messageData, s3Path, eventSourceArn } = input
+  const { messageData, s3Path, eventSourceArn, eventSourceQueueName } = input
   // General events are in base64 encoded XML
   const xml = decodeBase64(messageData)
   const logItem = await parseXml<GeneralEventLogItem>(xml)
@@ -16,7 +16,7 @@ const GeneralEventTranslator: Translator = async (input: TranslateEventInput): P
     return new Error("Failed to parse the General Event")
   }
 
-  const event = transformEventDetails(logItem.logEvent, s3Path, eventSourceArn)
+  const event = transformEventDetails(logItem.logEvent, s3Path, eventSourceArn, eventSourceQueueName)
   return {
     messageId: logItem.logEvent.correlationID,
     event

--- a/src/lambdas/translate-event/src/translators/transformEventDetails.ts
+++ b/src/lambdas/translate-event/src/translators/transformEventDetails.ts
@@ -15,7 +15,12 @@ const mapEventCategory = (category: string): EventCategory => {
   }
 }
 
-export default (eventDetails: EventDetails, s3Path: string, eventSourceArn: string): BichardAuditLogEvent => {
+export default (
+  eventDetails: EventDetails,
+  s3Path: string,
+  eventSourceArn: string,
+  eventSourceQueueName: string
+): BichardAuditLogEvent => {
   const { eventCategory, eventDateTime, eventType, componentID, nameValuePairs } = eventDetails
 
   const category = mapEventCategory(eventCategory)
@@ -27,7 +32,8 @@ export default (eventDetails: EventDetails, s3Path: string, eventSourceArn: stri
     eventType,
     timestamp,
     s3Path,
-    eventSourceArn
+    eventSourceArn,
+    eventSourceQueueName
   })
 
   const attributes = nameValuePairs?.nameValuePair


### PR DESCRIPTION
- Added `eventSourceQueueName` to `BichardAuditLogEvent` class
- Updated `message-receiver` to populate the value from `destination.physicalName` in the AMQ request
- Updated `embellishMessages` function to remove `.FAILURE` from the queue name