### PR TITLE
Refactor record event lambda

### DIFF
--- a/src/@bichard/s3/src/AwsS3Gateway.integration.test.ts
+++ b/src/@bichard/s3/src/AwsS3Gateway.integration.test.ts
@@ -118,7 +118,7 @@ describe("AwsS3Gateway", () => {
       expect(isError(result)).toBe(true)
 
       const actualError = result as Error
-      expect(actualError.name).toBe("NotFound")
+      expect(actualError.name).toBe("NoSuchKey")
     })
   })
 })

--- a/src/lambdas/record-event/src/CreateEventUseCase.test.ts
+++ b/src/lambdas/record-event/src/CreateEventUseCase.test.ts
@@ -1,7 +1,6 @@
 import "@bichard/testing-jest"
 import { FakeApiClient } from "@bichard/testing-api-client"
 import type { AuditLogEvent } from "shared"
-import type { ApiClient } from "@bichard/api-client"
 import CreateEventUseCase from "./CreateEventUseCase"
 
 describe("execute", () => {
@@ -25,17 +24,6 @@ describe("execute", () => {
     expect(result).toBeUndefined()
   })
 
-  it("should fail when audit log API fails to get message", async () => {
-    const expectedError = new Error("Get message failed")
-    const useCase = new CreateEventUseCase(fakeApiClient)
-
-    fakeApiClient.reset()
-    fakeApiClient.shouldReturnError(expectedError, ["getMessage"])
-    const result = await useCase.execute("DummyMessageId", {} as AuditLogEvent)
-
-    expect(result).toBeError(expectedError.message)
-  })
-
   it("should fail when audit log API fails to create message", async () => {
     const expectedError = new Error("Create audit log failed")
     const useCase = new CreateEventUseCase(fakeApiClient)
@@ -56,47 +44,5 @@ describe("execute", () => {
     const result = await useCase.execute("DummyMessageId", {} as AuditLogEvent)
 
     expect(result).toBeError(expectedError.message)
-  })
-})
-
-describe("retryExecute", () => {
-  const useCase = new CreateEventUseCase({} as ApiClient)
-
-  it("should not retry more than 3 times", async () => {
-    const expectedError = Error("Request failed with status code 409")
-    let retries = 0
-    jest.spyOn(useCase, "execute").mockImplementation(() => {
-      retries += 1
-      return Promise.resolve(expectedError)
-    })
-    const result = await useCase.retryExecute("DummyMessageId", {} as AuditLogEvent)
-
-    expect(result).toBeError(expectedError.message)
-    expect(retries).toEqual(3)
-  })
-
-  it("should not retry when non-cnflict error is returned", async () => {
-    const expectedError = Error("Other errors")
-    let retries = 0
-    jest.spyOn(useCase, "execute").mockImplementation(() => {
-      retries += 1
-      return Promise.resolve(expectedError)
-    })
-    const result = await useCase.retryExecute("DummyMessageId", {} as AuditLogEvent)
-
-    expect(result).toBeError(expectedError.message)
-    expect(retries).toEqual(1)
-  })
-
-  it("should not retry when there is no error", async () => {
-    let retries = 0
-    jest.spyOn(useCase, "execute").mockImplementation(() => {
-      retries += 1
-      return Promise.resolve()
-    })
-    const result = await useCase.retryExecute("DummyMessageId", {} as AuditLogEvent)
-
-    expect(result).toNotBeError()
-    expect(retries).toEqual(1)
   })
 })

--- a/src/lambdas/record-event/src/index.ts
+++ b/src/lambdas/record-event/src/index.ts
@@ -22,7 +22,7 @@ const api = new AuditLogApiClient(apiUrl, apiKey)
 const useCase = new CreateEventUseCase(api)
 
 export default async ({ messageId, event }: RecordEventInput): Promise<void> => {
-  const result = await useCase.retryExecute(messageId, event)
+  const result = await useCase.execute(messageId, event)
 
   if (isError(result)) {
     throw result


### PR DESCRIPTION
Removed the retry logic from the `record-event` lambda as it wasn't necessary and was making the code complicated.
`record-event` lambda now tries to create a message for all events regardless of whether the message exists or not. In case the message already exists in DynamoDB table, the API returns 409 and the logic creates the event against the message.