### PR TITLE
Truncate attributes from autit log events if they are too long

### DIFF
--- a/shared/src/types/AuditLogEvent.test.ts
+++ b/shared/src/types/AuditLogEvent.test.ts
@@ -1,0 +1,38 @@
+import { AuditLogEvent } from "."
+import type { AuditLogEventOptions } from "."
+
+const defaultOptions: AuditLogEventOptions = {
+  eventSource: "test",
+  eventType: "test",
+  category: "information",
+  timestamp: new Date()
+}
+
+describe("AuditLogEvent", () => {
+  describe("addAttribute", () => {
+    it("should truncate the attribute if the text is too long", () => {
+      const value = "x".repeat(2000)
+      const log = new AuditLogEvent(defaultOptions)
+      log.addAttribute("test", value)
+      const attrValue: string = log.attributes.test as string
+      expect(attrValue).toHaveLength(1000)
+      expect(attrValue.endsWith("xxx...[truncated]")).toBeTruthy()
+    })
+
+    it("should not truncate the attribute if the text is not too long", () => {
+      const value = "x".repeat(1000)
+      const log = new AuditLogEvent(defaultOptions)
+      log.addAttribute("test", value)
+      const attrValue: string = log.attributes.test as string
+      expect(attrValue).toHaveLength(1000)
+      expect(attrValue).toEqual(value)
+    })
+
+    it("should only try to truncate if the value is a string", () => {
+      const value = 999
+      const log = new AuditLogEvent(defaultOptions)
+      log.addAttribute("test", value)
+      expect(log.attributes.test).toEqual(value)
+    })
+  })
+})

--- a/shared/src/types/AuditLogEvent.ts
+++ b/shared/src/types/AuditLogEvent.ts
@@ -21,6 +21,12 @@ export default class AuditLogEvent {
   }
 
   addAttribute(name: string, value: unknown): void {
-    this.attributes[name] = value
+    const maxStringLength = 1000
+    const truncateString = "...[truncated]"
+    let valueToAdd = value
+    if (typeof valueToAdd === "string" && valueToAdd.length > maxStringLength) {
+      valueToAdd = valueToAdd.substring(0, maxStringLength - truncateString.length) + truncateString
+    }
+    this.attributes[name] = valueToAdd
   }
 }


### PR DESCRIPTION
This is so that we can log stack traces without worrying about overflowing the max record size in Dynamo so much.