### PR TITLE
Fix message retry

### DIFF
--- a/audit-log-api/src/handlers/retryMessage.e2e.test.ts
+++ b/audit-log-api/src/handlers/retryMessage.e2e.test.ts
@@ -1,7 +1,7 @@
 jest.setTimeout(15000)
 
 import fs from "fs"
-import { AuditLog, BichardAuditLogEvent, HttpStatusCode } from "shared"
+import { AuditLog, BichardAuditLogEvent, encodeBase64, HttpStatusCode } from "shared"
 import TestDynamoGateway from "shared/dist/DynamoGateway/TestDynamoGateway"
 import { setEnvironmentVariables } from "@bichard/testing-config"
 import createDynamoDbConfig from "src/createDynamoDbConfig"
@@ -30,8 +30,16 @@ describe("retryMessage", () => {
   })
 
   it("should return Ok status when message has been retried successfully", async () => {
+    const event = {
+      messageData: encodeBase64("<Xml></Xml>"),
+      messageFormat: "Dummy Event Source",
+      eventSourceArn: "Dummy Event Arn",
+      eventSourceQueueName: "DUMMY_QUEUE"
+    }
+
     const s3Path = "event.xml"
-    await s3Gateway.upload(s3Path, "<Xml></Xml>")
+    await s3Gateway.upload(s3Path, JSON.stringify(event))
+
     const message = new AuditLog("External Correlation ID", new Date(), "Xml")
     message.events.push(
       new BichardAuditLogEvent({

--- a/audit-log-api/src/handlers/retryMessage.ts
+++ b/audit-log-api/src/handlers/retryMessage.ts
@@ -5,7 +5,7 @@ import createDynamoDbConfig from "src/createDynamoDbConfig"
 import { parseRetryMessageRequest, RetryMessageUseCase } from "src/use-cases"
 import { createJsonApiResult } from "src/utils"
 import { StompitMqGateway, createMqConfig } from "@bichard/mq"
-import GetLastEventUseCase from "src/use-cases/GetLastEventUseCase"
+import GetLastFailedMessageEventUseCase from "src/use-cases/GetLastEventUseCase"
 import { AuditLogApiClient } from "@bichard/api-client"
 import { AwsS3Gateway } from "@bichard/s3"
 import getApiUrl from "src/getApiUrl"
@@ -26,7 +26,7 @@ const awsS3Gateway = new AwsS3Gateway(createS3Config())
 const retrieveEventXmlFromS3UseCase = new RetrieveEventXmlFromS3UseCase(awsS3Gateway)
 
 const apiClient = new AuditLogApiClient(getApiUrl(), getApiKey())
-const getLastEventUseCase = new GetLastEventUseCase(auditLogGateway)
+const getLastEventUseCase = new GetLastFailedMessageEventUseCase(auditLogGateway)
 const createRetryingEventUseCase = new CreateRetryingEventUseCase(apiClient)
 
 const retryMessageUseCase = new RetryMessageUseCase(

--- a/audit-log-api/src/use-cases/GetLastEventUseCase.test.ts
+++ b/audit-log-api/src/use-cases/GetLastEventUseCase.test.ts
@@ -2,10 +2,10 @@ import "@bichard/testing-jest"
 import { FakeAuditLogDynamoGateway } from "@bichard/testing-dynamodb"
 import type { EventCategory, BichardAuditLogEvent } from "shared"
 import { AuditLog, AuditLogEvent } from "shared"
-import GetLastEventUseCase from "./GetLastEventUseCase"
+import GetLastFailedMessageEventUseCase from "./GetLastEventUseCase"
 
 const auditLogDynamoGateway = new FakeAuditLogDynamoGateway()
-const useCase = new GetLastEventUseCase(auditLogDynamoGateway)
+const useCase = new GetLastFailedMessageEventUseCase(auditLogDynamoGateway)
 
 const createAuditLog = (): AuditLog => new AuditLog("External Correlation Id", new Date("2021-07-22T08:10:10"), "Xml")
 const createEvent = (date: string, category: EventCategory): AuditLogEvent => {

--- a/audit-log-api/src/use-cases/GetLastEventUseCase.ts
+++ b/audit-log-api/src/use-cases/GetLastEventUseCase.ts
@@ -1,20 +1,24 @@
 import type { AuditLogDynamoGateway, BichardAuditLogEvent, PromiseResult } from "shared"
 import { isError } from "shared"
 
-export default class GetLastEventUseCase {
+export default class GetLastFailedMessageEventUseCase {
   constructor(private readonly auditLogDynamoGateway: AuditLogDynamoGateway) {}
 
   async get(messageId: string): PromiseResult<BichardAuditLogEvent> {
-    const events = await this.auditLogDynamoGateway.fetchEvents(messageId)
+    const events = (await this.auditLogDynamoGateway.fetchEvents(messageId)) as BichardAuditLogEvent[]
 
     if (isError(events)) {
       return events
     }
 
-    if (events.length === 0) {
+    const failedEvents = events.filter(
+      (event) => event.category === "error" && event.s3Path && event.eventSourceQueueName
+    )
+
+    if (failedEvents.length === 0) {
       return new Error(`No events found for message '${messageId}'`)
     }
 
-    return events[0] as BichardAuditLogEvent
+    return failedEvents.slice(-1)[0]
   }
 }

--- a/audit-log-api/src/use-cases/RetryMessageUseCase.integration.test.ts
+++ b/audit-log-api/src/use-cases/RetryMessageUseCase.integration.test.ts
@@ -11,7 +11,7 @@ import createS3Config from "src/createS3Config"
 import { createMqConfig, TestStompitMqGateway } from "@bichard/mq"
 import { TestAwsS3Gateway } from "@bichard/s3"
 import RetryMessageUseCase from "./RetryMessageUseCase"
-import GetLastEventUseCase from "./GetLastEventUseCase"
+import GetLastFailedMessageEventUseCase from "./GetLastEventUseCase"
 import SendMessageToQueueUseCase from "./SendMessageToQueueUseCase"
 import RetrieveEventXmlFromS3UseCase from "./RetrieveEventXmlFromS3UseCase"
 import CreateRetryingEventUseCase from "./CreateRetryingEventUseCase"
@@ -30,7 +30,7 @@ setEnvironmentVariables({
 const dynamoDbConfig = createDynamoDbConfig()
 const testDynamoGateway = new TestDynamoGateway(dynamoDbConfig)
 const auditLogDynamoGateway = new AwsAuditLogDynamoGateway(dynamoDbConfig, dynamoDbConfig.AUDIT_LOG_TABLE_NAME)
-const getLastEventUseCase = new GetLastEventUseCase(auditLogDynamoGateway)
+const getLastEventUseCase = new GetLastFailedMessageEventUseCase(auditLogDynamoGateway)
 
 const queueName = "retry-event-integration-testing"
 const mqConfig = createMqConfig()

--- a/audit-log-api/src/use-cases/RetryMessageUseCase.integration.test.ts
+++ b/audit-log-api/src/use-cases/RetryMessageUseCase.integration.test.ts
@@ -65,7 +65,14 @@ describe("RetryMessageUseCase", () => {
   })
 
   it("should retry message when last event is error", async () => {
-    await s3Gateway.upload(eventXmlFileName, encodeBase64(eventXml))
+    const event = {
+      messageData: encodeBase64(eventXml),
+      messageFormat: "Dummy Event Source",
+      eventSourceArn: "Dummy Event Arn",
+      eventSourceQueueName: queueName
+    }
+
+    await s3Gateway.upload(eventXmlFileName, JSON.stringify(event))
 
     const message = new AuditLog("External Correlation ID", new Date(), "Xml")
     message.events.push(

--- a/audit-log-api/src/use-cases/SendMessageToQueueUseCase.ts
+++ b/audit-log-api/src/use-cases/SendMessageToQueueUseCase.ts
@@ -1,12 +1,10 @@
 import type { MqGateway } from "@bichard/mq"
 import type { PromiseResult } from "shared"
-import { decodeBase64 } from "shared"
 
 export default class SendMessageToQueueUseCase {
   constructor(private mqGateway: MqGateway) {}
 
   send(queueName: string, message: string): PromiseResult<void> {
-    const decodedMessage = decodeBase64(message)
-    return this.mqGateway.execute(decodedMessage, queueName)
+    return this.mqGateway.execute(message, queueName)
   }
 }

--- a/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.integration.test.ts
+++ b/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.integration.test.ts
@@ -507,7 +507,7 @@ describe("AuditLogDynamoGateway", () => {
   })
 
   describe("fetchEvents", () => {
-    it("should return AuditLogEvents ordered by timestamp when message id exists in the table", async () => {
+    it("should return AuditLogEvents when message id exists in the table", async () => {
       const auditLog = new AuditLog(`External correlation id 1`, new Date(), "XML")
       auditLog.events = [
         createAuditLogEvent("information", new Date("2021-06-10T10:12:13"), "Event 1"),
@@ -523,9 +523,9 @@ describe("AuditLogDynamoGateway", () => {
 
       const events = <AuditLogEvent[]>result
       expect(events).toHaveLength(3)
-      expect(events[0].eventType).toBe("Event 2")
-      expect(events[1].eventType).toBe("Event 3")
-      expect(events[2].eventType).toBe("Event 1")
+      expect(events[0].eventType).toBe("Event 1")
+      expect(events[1].eventType).toBe("Event 2")
+      expect(events[2].eventType).toBe("Event 3")
     })
 
     it("should return an empty array when message does not have events", async () => {

--- a/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
+++ b/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
@@ -114,9 +114,7 @@ export default class AwsAuditLogDynamoGateway extends DynamoGateway implements A
       return []
     }
 
-    const sortedEvents = result.events.sort((eventA, eventB) => (eventA.timestamp > eventB.timestamp ? -1 : 1))
-
-    return sortedEvents
+    return result.events
   }
 
   async addEvent(messageId: string, messageVersion: number, event: AuditLogEvent): PromiseResult<void> {


### PR DESCRIPTION
This PR fixes a number of issues that were preventing the message retry button (i.e. the retry API endpoint) from working properly.

These issues included:
- Making the assumption that the objects in S3 were just raw base64'ed XML, when actually they are JSON objects with the base64 XML as one key on the object
- Explicitly using timestamps to order the events for a message, when actually these are unreliable and we should instead be using the order of the events within the message object
- Making the assumption that the last event for a message is always the failed one, when this isn't always the case