### PR TITLE
Improve building by Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,9 @@ jobs:
       - restore_cache:
           key: v1-npm-deps-{{ checksum "mq-listener/package-lock.json" }}
 
-      - run: make build
+      - run: make install
+
+      - run: make build-all
 
       - run:
           name: Build Portal Stories

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,23 @@ audit-log-api: audit-log-api/build
 audit-log-portal: audit-log-portal/.next
 
 define get_source_files
-	$(shell find $(1) -type f ! -path dist ! -path build ! -path .next ! -path .storybook ! ! -path documentation -path *node_modules*)
+	$(shell find $(1) \
+		\( \
+			-name node_modules -o \
+			-name .next -o \
+			-name build -o \
+			-name dist \
+		\) -prune -o \
+		-type f \( \
+			-iname '*.js' -o \
+			-iname '*.json' -o \
+			-iname '*.jsx' -o \
+			-iname '*.sh' -o \
+			-iname '*.snap' -o \
+			-iname '*.ts' -o \
+			-iname '*.tsx'
+		\) -print \
+	)
 endef
 
 # Source files for each package

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ audit-log-api: audit-log-api/build
 audit-log-portal: audit-log-portal/.next
 
 define get_source_files
-	$(shell find $(1) -type f ! -path dist ! -path build ! -path .next ! -path .storybook ! -path *node_modules*)
+	$(shell find $(1) -type f ! -path dist ! -path build ! -path .next ! -path .storybook ! ! -path documentation -path *node_modules*)
 endef
 
 # Source files for each package
@@ -58,37 +58,37 @@ AUDIT_LOG_PORTAL_SOURCE := $(call get_source_files,audit-log-portal)
 shared-types/dist: $(SHARED_TYPES_SOURCE)
 	cd shared-types && npm run build
 
-shared-testing/dist: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE)
+shared-testing/dist: shared-types/dist $(SHARED_TESTING_SOURCE)
 	cd shared-testing && npm run build
 
-shared/dist: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE) $(SHARED_SOURCE)
+shared/dist: shared-types/dist shared-testing/dist $(SHARED_SOURCE)
 	cd shared && npm run build
 
-src/lambdas/retrieve-event-from-s3/build: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE) $(SHARED_SOURCE) $(RETRIEVE_EVENT_FROM_S3_SOURCE)
+src/lambdas/retrieve-event-from-s3/build: shared-types/dist shared-testing/dist shared/dist $(RETRIEVE_EVENT_FROM_S3_SOURCE)
 	cd src/lambdas/retrieve-event-from-s3 && npm run build
 
-src/lambdas/translate-event/build: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE) $(SHARED_SOURCE) $(TRANSLATE_EVENT_SOURCE)
+src/lambdas/translate-event/build: shared-types/dist shared-testing/dist shared/dist $(TRANSLATE_EVENT_SOURCE)
 	cd src/lambdas/translate-event && npm run build
 
-src/lambdas/record-event/build: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE) $(SHARED_SOURCE) $(RECORD_EVENT_SOURCE)
+src/lambdas/record-event/build: shared-types/dist shared-testing/dist shared/dist $(RECORD_EVENT_SOURCE)
 	cd src/lambdas/record-event && npm run build
 
-src/lambdas/message-receiver/build: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE) $(SHARED_SOURCE) $(MESSAGE_RECEIVER_SOURCE)
+src/lambdas/message-receiver/build: shared-types/dist shared-testing/dist shared/dist $(MESSAGE_RECEIVER_SOURCE)
 	cd src/lambdas/message-receiver && npm run build
 
-src/lambdas/transfer-messages/build: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE) $(SHARED_SOURCE) $(TRANSFER_MESSAGES_SOURCE)
+src/lambdas/transfer-messages/build: shared-types/dist shared-testing/dist shared/dist $(TRANSFER_MESSAGES_SOURCE)
 	cd src/lambdas/transfer-messages && npm run build
 
 .PHONY: event-handler
-event-handler: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE) $(SHARED_SOURCE)
+event-handler: shared-types/dist shared-testing/dist shared/dist
 
-incoming-message-handler/build: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE) $(SHARED_SOURCE) $(INCOMING_MESSAGE_HANDLER_SOURCE)
+incoming-message-handler/build: shared-types/dist shared-testing/dist shared/dist $(INCOMING_MESSAGE_HANDLER_SOURCE)
 	cd incoming-message-handler && npm run build
 
-audit-log-api/build: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE) $(SHARED_SOURCE) $(AUDIT_LOG_API_SOURCE)
+audit-log-api/build: shared-types/dist shared-testing/dist shared/dist $(AUDIT_LOG_API_SOURCE)
 	cd audit-log-api && npm run build
 
-audit-log-portal/.next: $(SHARED_TYPES_SOURCE) $(SHARED_SOURCE) $(AUDIT_LOG_PORTAL_SOURCE)
+audit-log-portal/.next: shared-types/dist shared/dist $(AUDIT_LOG_PORTAL_SOURCE)
 	cd audit-log-portal && npm run build
 
 # Clean

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ validate:
 # Build Commands
 ########################################
 
-# Aliases
+# Package => build output aliases
 shared-types: shared-types/dist
 shared-testing: shared-testing/dist
 shared: shared/dist
@@ -37,19 +37,24 @@ incoming-message-handler: incoming-message-handler/build
 audit-log-api: audit-log-api/build
 audit-log-portal: audit-log-portal/.next
 
-# Source files for each target
-SHARED_TYPES_SOURCE := $(shell find shared-types -type f ! -path dist ! -path *node_modules*)
-SHARED_TESTING_SOURCE := $(shell find shared-testing -type f ! -path dist ! -path *node_modules*)
-SHARED_SOURCE := $(shell find shared -type f ! -path dist ! -path *node_modules*)
-RETRIEVE_EVENT_FROM_S3_SOURCE := $(shell find src/lambdas/retrieve-event-from-s3 -type f ! -path build ! -path *node_modules*)
-TRANSLATE_EVENT_SOURCE := $(shell find src/lambdas/translate-event -type f ! -path build ! -path *node_modules*)
-RECORD_EVENT_SOURCE := $(shell find src/lambdas/record-event -type f ! -path build ! -path *node_modules*)
-MESSAGE_RECEIVER_SOURCE := $(shell find src/lambdas/message-receiver -type f ! -path build ! -path *node_modules*)
-TRANSFER_MESSAGES_SOURCE := $(shell find src/lambdas/transfer-messages -type f ! -path build ! -path *node_modules*)
-INCOMING_MESSAGE_HANDLER_SOURCE := $(shell find incoming-message-handler -type f ! -path build ! -path *node_modules*)
-AUDIT_LOG_API_SOURCE := $(shell find audit-log-api -type f ! -path build ! -path *node_modules*)
-AUDIT_LOG_PORTAL_SOURCE := $(shell find audit-log-portal -type f ! -path .next ! -path *node_modules* ! -path .storybook)
+define get_source_files
+	$(shell find $(1) -type f ! -path dist ! -path build ! -path .next ! -path .storybook ! -path *node_modules*)
+endef
 
+# Source files for each package
+SHARED_TYPES_SOURCE := $(call get_source_files,shared-types)
+SHARED_TESTING_SOURCE := $(call get_source_files,shared-testing)
+SHARED_SOURCE := $(call get_source_files,shared)
+RETRIEVE_EVENT_FROM_S3_SOURCE := $(call get_source_files,src/lambdas/retrieve-event-from-s3)
+TRANSLATE_EVENT_SOURCE := $(call get_source_files,src/lambdas/translate-event)
+RECORD_EVENT_SOURCE := $(call get_source_files,src/lambdas/record-event)
+MESSAGE_RECEIVER_SOURCE := $(call get_source_files,src/lambdas/message-receiver)
+TRANSFER_MESSAGES_SOURCE := $(call get_source_files,src/lambdas/transfer-messages)
+INCOMING_MESSAGE_HANDLER_SOURCE := $(call get_source_files,incoming-message-handler)
+AUDIT_LOG_API_SOURCE := $(call get_source_files,audit-log-api)
+AUDIT_LOG_PORTAL_SOURCE := $(call get_source_files,audit-log-portal)
+
+# How to build each package
 shared-types/dist: $(SHARED_TYPES_SOURCE)
 	cd shared-types && npm run build
 
@@ -86,7 +91,7 @@ audit-log-api/build: $(SHARED_TYPES_SOURCE) $(SHARED_TESTING_SOURCE) $(SHARED_SO
 audit-log-portal/.next: $(SHARED_TYPES_SOURCE) $(SHARED_SOURCE) $(AUDIT_LOG_PORTAL_SOURCE)
 	cd audit-log-portal && npm run build
 
-# CLEAN
+# Clean
 .PHONY: clean
 clean:
 	rm -rf \

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ SHELL := /bin/bash
 install:
 	scripts/install-all-ci.sh
 
-.PHONY: build
-build: install
+.PHONY: build-all
+build-all:
 	scripts/build-all.sh
 
 .PHONY: test
@@ -36,11 +36,6 @@ transfer-messages: src/lambdas/transfer-messages/build
 incoming-message-handler: incoming-message-handler/build
 audit-log-api: audit-log-api/build
 audit-log-portal: audit-log-portal/.next
-
-all: shared-types/dist shared-testing/dist shared/dist src/lambdas/retrieve-event-from-s3/build \
-	src/lambdas/translate-event/build src/lambdas/record-event/build \
-	src/lambdas/message-receiver/build src/lambdas/transfer-messages/build \
-	incoming-message-handler/build audit-log-api/build audit-log-portal/.next
 
 define get_source_files
 	$(shell find $(1) \

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ incoming-message-handler: incoming-message-handler/build
 audit-log-api: audit-log-api/build
 audit-log-portal: audit-log-portal/.next
 
+all: shared-types/dist shared-testing/dist shared/dist src/lambdas/retrieve-event-from-s3/build \
+	src/lambdas/translate-event/build src/lambdas/record-event/build \
+	src/lambdas/message-receiver/build src/lambdas/transfer-messages/build \
+	incoming-message-handler/build audit-log-api/build audit-log-portal/.next
+
 define get_source_files
 	$(shell find $(1) \
 		\( \

--- a/Makefile
+++ b/Makefile
@@ -113,31 +113,23 @@ clean:
 
 .PHONY: run-mq-listener
 run-mq-listener: destroy-mq-listener
-	cd ./mq-listener && npm run start && cd -
+	cd mq-listener && npm run start
 
 .PHONY: run-incoming-message-handler
 run-incoming-message-handler:
-	cd ./incoming-message-handler && \
-		npm run setup:env && \
-		cd -
+	cd incoming-message-handler && npm run setup:env
 
 .PHONY: run-api
 run-api:
-	cd ./audit-log-api && \
-		npm run start && \
-		cd -
+	cd audit-log-api && npm run start
 
 .PHONY: run-portal
 run-portal:
-	cd ./audit-log-portal && \
-		npm run start && \
-		cd -
+	cd audit-log-portal && npm run start
 
 .PHONY: run-event-handler
 run-event-handler:
-	cd ./src/event-handler && \
-		npm run setup:env && \
-		cd -
+	cd src/event-handler && npm run setup:env
 
 .PHONY: run-all-without-portal
 run-all-without-portal: run-api run-incoming-message-handler run-event-handler
@@ -158,7 +150,7 @@ run-all-e2e:
 
 .PHONY: destroy-mq-listener
 destroy-mq-listener:
-	cd ./mq-listener && npm run stop && cd -
+	cd mq-listener && npm run stop
 
 .PHONY: destroy-infra
 destroy-infra:
@@ -189,7 +181,7 @@ follow-logs:
 
 .PHONY: follow-mq-listener-logs
 follow-mq-listener-logs:
-	cd ./mq-listener && npm run logs && cd -
+	cd mq-listener && npm run logs
 
 .PHONY: scan-db
 scan-db:
@@ -197,9 +189,7 @@ scan-db:
 
 .PHONY: send-message
 send-message:
-	cd incoming-message-handler && \
-		scripts/trigger-state-machine.sh && \
-		cd -
+	cd incoming-message-handler && scripts/trigger-state-machine.sh
 
 .PHONY: send-court-result-input-failure-event
 send-court-result-input-failure-event:


### PR DESCRIPTION
This PR adds a separate make target for each of the distinct packages in the audit-logging repo. Each of these targets is aware of the dependencies that it has on other packages within the repo.

For example, if you're working on the `audit-log-api` package and make a change to the base `shared-types` repository, you'll then need to re-compile the `shared-types`, `shared-testing`, `shared` and then `audit-log-api` packages in order to fully integrate your changes.

This PR lets you run:

```shell
$ make audit-log-api
```

in order to check whether any of the dependencies for `audit-log-api` need building, build them, and then finally build `audit-log-api` itself.

This PR also includes a `make clean` command, which removes the build output folders from all packages in the repo.

**N.B.** Due to the way that the makefile is calculating the files used to build each package (which is using `find`), there's a slight delay of 2-3 seconds whenever running a make command. We should try and optimise this in the future.