### PR TITLE
Add per-package makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,11 @@ audit-log-portal: audit-log-portal/.next
 define get_source_files
 	$(shell find $(1) \
 		\( \
-			-name node_modules -o \
 			-name .next -o \
 			-name build -o \
-			-name dist \
+			-name dist -o \
+			-name documentation -o \
+			-name node_modules \
 		\) -prune -o \
 		-type f \( \
 			-iname '*.js' -o \

--- a/audit-log-api/Makefile
+++ b/audit-log-api/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C .. audit-log-api

--- a/audit-log-portal/Makefile
+++ b/audit-log-portal/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C .. audit-log-portal

--- a/incoming-message-handler/Makefile
+++ b/incoming-message-handler/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C .. incoming-message-handler

--- a/shared-testing/Makefile
+++ b/shared-testing/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C .. shared-testing

--- a/shared-types/Makefile
+++ b/shared-types/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C .. shared-types

--- a/shared/Makefile
+++ b/shared/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C .. shared

--- a/src/event-handler/Makefile
+++ b/src/event-handler/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C ../.. event-handler

--- a/src/lambdas/message-receiver/Makefile
+++ b/src/lambdas/message-receiver/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C ../../.. message-receiver

--- a/src/lambdas/record-event/Makefile
+++ b/src/lambdas/record-event/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C ../../.. record-event

--- a/src/lambdas/retrieve-event-from-s3/Makefile
+++ b/src/lambdas/retrieve-event-from-s3/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C ../../.. retrieve-event-from-s3

--- a/src/lambdas/transfer-messages/Makefile
+++ b/src/lambdas/transfer-messages/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C ../../.. transfer-messages

--- a/src/lambdas/translate-event/Makefile
+++ b/src/lambdas/translate-event/Makefile
@@ -1,0 +1,2 @@
+build:
+	make -C ../../.. translate-event


### PR DESCRIPTION
This PR adds a small Makefile to each package, allowing you to run `make build` from the root of the package.

Calling `make build` from the package simply calls the corresponding `make <package-name>` from the main Makefile in the root of the repo.