### PR TITLE
Add systemId to AuditLog

### DIFF
--- a/src/audit-log-api/src/use-cases/validateCreateAuditLog.test.ts
+++ b/src/audit-log-api/src/use-cases/validateCreateAuditLog.test.ts
@@ -4,6 +4,7 @@ import validateCreateAuditLog from "./validateCreateAuditLog"
 it("should be valid when audit log item is valid", () => {
   const item = new AuditLog("ECID", new Date(), "XML")
   item.caseId = "CID"
+  item.systemId = "DummySystemID"
   item.createdBy = "Test"
   const { errors, isValid, auditLog } = validateCreateAuditLog(item)
 
@@ -13,6 +14,7 @@ it("should be valid when audit log item is valid", () => {
   expect(auditLog.messageId).toBe(item.messageId)
   expect(auditLog.externalCorrelationId).toBe(item.externalCorrelationId)
   expect(auditLog.caseId).toBe(item.caseId)
+  expect(auditLog.systemId).toBe(item.systemId)
   expect(auditLog.receivedDate).toBe(item.receivedDate)
   expect(auditLog.messageXml).toBe(item.messageXml)
   expect(auditLog.createdBy).toBe(item.createdBy)
@@ -26,6 +28,7 @@ it("should be valid when audit log item is valid", () => {
 it("should be valid and override the value of fields that should be set internally", () => {
   const item = new AuditLog("ECID", new Date("2021-10-15T10:12:13.000Z"), "XML")
   item.caseId = "CID"
+  item.systemId = "DummySystemID"
   item.createdBy = "Test"
 
   const itemToFix = {
@@ -44,6 +47,7 @@ it("should be valid and override the value of fields that should be set internal
   expect(auditLog).toBeDefined()
   expect(auditLog.messageId).toBe(item.messageId)
   expect(auditLog.caseId).toBe(item.caseId)
+  expect(auditLog.systemId).toBe(item.systemId)
   expect(auditLog.externalCorrelationId).toBe(item.externalCorrelationId)
   expect(auditLog.messageXml).toBe(item.messageXml)
   expect(auditLog.receivedDate).toEqual(item.receivedDate)
@@ -57,6 +61,7 @@ it("should be valid and override the value of fields that should be set internal
 it("should remove arbitrary keys from the audit log", () => {
   let item = new AuditLog("ECID", new Date(), "XML")
   item.caseId = "CID"
+  item.systemId = "DummySystemID"
   item.createdBy = "Test"
   item = { ...item, randomKey1: "RandomValue", key2: 5 } as AuditLog
   const { errors, isValid, auditLog } = validateCreateAuditLog(item)
@@ -67,6 +72,7 @@ it("should remove arbitrary keys from the audit log", () => {
   expect(auditLog.messageId).toBe(item.messageId)
   expect(auditLog.externalCorrelationId).toBe(item.externalCorrelationId)
   expect(auditLog.caseId).toBe(item.caseId)
+  expect(auditLog.systemId).toBe(item.systemId)
   expect(auditLog.receivedDate).toBe(item.receivedDate)
   expect(auditLog.messageXml).toBe(item.messageXml)
   expect(auditLog.status).toBe(item.status)
@@ -98,6 +104,7 @@ it("should be invalid when fields have incorrect format", () => {
   const item = {
     messageId: 1,
     caseId: 2,
+    systemId: 3,
     externalCorrelationId: 3,
     messageXml: 4,
     receivedDate: "2021-10-05 12:13:14",
@@ -106,8 +113,9 @@ it("should be invalid when fields have incorrect format", () => {
   const { errors, isValid } = validateCreateAuditLog(item)
 
   expect(isValid).toBe(false)
-  expect(errors).toHaveLength(6)
+  expect(errors).toHaveLength(7)
   expect(errors).toContain("Case ID must be string")
+  expect(errors).toContain("System ID must be string")
   expect(errors).toContain("External Correlation ID must be string")
   expect(errors).toContain("Message ID must be string")
   expect(errors).toContain("Message XML must be string")

--- a/src/audit-log-api/src/use-cases/validateCreateAuditLog.ts
+++ b/src/audit-log-api/src/use-cases/validateCreateAuditLog.ts
@@ -13,6 +13,7 @@ export default (auditLog: AuditLog): ValidationResult => {
   let formattedReceivedDate = ""
   const {
     caseId,
+    systemId,
     externalCorrelationId,
     messageId,
     messageXml,
@@ -27,6 +28,10 @@ export default (auditLog: AuditLog): ValidationResult => {
     errors.push("Case ID is mandatory")
   } else if (typeof caseId !== "string") {
     errors.push("Case ID must be string")
+  }
+
+  if (systemId && typeof systemId !== "string") {
+    errors.push("System ID must be string")
   }
 
   if (!externalCorrelationId) {
@@ -83,6 +88,7 @@ export default (auditLog: AuditLog): ValidationResult => {
   const validatedAuditLog: AuditLog = {
     messageId,
     caseId,
+    systemId,
     s3Path,
     externalId,
     stepExecutionId,

--- a/src/incoming-message-handler/src/entities/DeliveryMessage.ts
+++ b/src/incoming-message-handler/src/entities/DeliveryMessage.ts
@@ -2,6 +2,7 @@ type DeliveryMessage = {
   RouteData: {
     RequestFromSystem: {
       CorrelationID: string
+      SystemID: string
     }
     DataStream: {
       DataStreamContent: {

--- a/src/incoming-message-handler/src/use-cases/readMessage.test.ts
+++ b/src/incoming-message-handler/src/use-cases/readMessage.test.ts
@@ -13,7 +13,35 @@ const formatXml = (xml: string): string =>
 
 const expectedExternalCorrelationId = uuid()
 const expectedCaseId = "41BP0510007"
+const expectedSystemId = "DUMMY_SYSTEM_ID"
 const expectedMessage = formatXml(`
+<?xml version="1.0" encoding="UTF-8"?>
+<RouteData xmlns="http://schemas.cjse.gov.uk/messages/deliver/2006-05" xmlns:ex="http://schemas.cjse.gov.uk/messages/exception/2006-06" xmlns:mf="http://schemas.cjse.gov.uk/messages/format/2006-05" xmlns:mm="http://schemas.cjse.gov.uk/messages/metadata/2006-05" xmlns:msg="http://schemas.cjse.gov.uk/messages/messaging/2006-05" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <RequestFromSystem>
+    <CorrelationID>
+      ${expectedExternalCorrelationId}
+    </CorrelationID>
+    <SystemID>
+      ${expectedSystemId}
+    </SystemID>
+  </RequestFromSystem>
+	<DataStream>
+    <DataStreamContent>
+      <DC:ResultedCaseMessage xmlns:DC="http://www.dca.gov.uk/xmlschemas/libra" Flow='ResultedCasesForThePolice' Interface='LibraStandardProsecutorPolice' SchemaVersion='0.6g'>
+        <DC:Session>
+          <DC:Case>
+            <DC:PTIURN>
+              ${expectedCaseId}
+            </DC:PTIURN>
+          </DC:Case>
+        </DC:Session>
+      </DC:ResultedCaseMessage>
+    </DataStreamContent>
+	</DataStream>
+</RouteData>
+`)
+
+const expectedMessageWithoutSystemId = formatXml(`
 <?xml version="1.0" encoding="UTF-8"?>
 <RouteData xmlns="http://schemas.cjse.gov.uk/messages/deliver/2006-05" xmlns:ex="http://schemas.cjse.gov.uk/messages/exception/2006-06" xmlns:mf="http://schemas.cjse.gov.uk/messages/format/2006-05" xmlns:mm="http://schemas.cjse.gov.uk/messages/metadata/2006-05" xmlns:msg="http://schemas.cjse.gov.uk/messages/messaging/2006-05" xmlns:xmime="http://www.w3.org/2005/05/xmlmime" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <RequestFromSystem>
@@ -50,12 +78,27 @@ describe("handleMessage", () => {
     message.messageXml = expectedMessage
 
     const result = (await readMessage(message)) as AuditLog
-    const { messageId, externalCorrelationId, caseId, createdBy, messageXml } = result
+    const { messageId, externalCorrelationId, caseId, systemId, createdBy, messageXml } = result
 
     expect(messageId).toBeDefined()
     expect(externalCorrelationId).toBe(expectedExternalCorrelationId)
     expect(messageXml).toBe(expectedMessage)
     expect(caseId).toEqual(expectedCaseId)
+    expect(systemId).toEqual(expectedSystemId)
+    expect(createdBy).toBe("Incoming message handler")
+  })
+
+  it("should read the message and return the message data when system ID does not exist", async () => {
+    message.messageXml = expectedMessageWithoutSystemId
+
+    const result = (await readMessage(message)) as AuditLog
+    const { messageId, externalCorrelationId, caseId, systemId, createdBy, messageXml } = result
+
+    expect(messageId).toBeDefined()
+    expect(externalCorrelationId).toBe(expectedExternalCorrelationId)
+    expect(messageXml).toBe(expectedMessageWithoutSystemId)
+    expect(caseId).toEqual(expectedCaseId)
+    expect(systemId).toBeUndefined()
     expect(createdBy).toBe("Incoming message handler")
   })
 

--- a/src/incoming-message-handler/src/use-cases/readMessage.ts
+++ b/src/incoming-message-handler/src/use-cases/readMessage.ts
@@ -32,12 +32,6 @@ const getExternalCorrelationId = (xml: DeliveryMessage): Result<string> => {
   return externalCorrelationId.trim()
 }
 
-const getSystemId = (xml: DeliveryMessage): string => {
-  const systemId = xml.RouteData && xml.RouteData.RequestFromSystem && xml.RouteData.RequestFromSystem.SystemID
-
-  return systemId?.trim()
-}
-
 const readMessage = async (message: ReceivedMessage): PromiseResult<AuditLog> => {
   const xml = await parseXml<DeliveryMessage>(message.messageXml).catch((error: Error) => error)
 
@@ -57,7 +51,7 @@ const readMessage = async (message: ReceivedMessage): PromiseResult<AuditLog> =>
 
   const auditLog = new AuditLog(externalCorrelationId, new Date(message.receivedDate), message.messageXml)
   auditLog.caseId = caseId
-  auditLog.systemId = getSystemId(xml)
+  auditLog.systemId = xml.RouteData?.RequestFromSystem?.SystemID?.trim()
   auditLog.createdBy = "Incoming message handler"
   auditLog.s3Path = message.s3Path
   auditLog.externalId = message.externalId

--- a/src/incoming-message-handler/src/use-cases/readMessage.ts
+++ b/src/incoming-message-handler/src/use-cases/readMessage.ts
@@ -32,6 +32,12 @@ const getExternalCorrelationId = (xml: DeliveryMessage): Result<string> => {
   return externalCorrelationId.trim()
 }
 
+const getSystemId = (xml: DeliveryMessage): string => {
+  const systemId = xml.RouteData && xml.RouteData.RequestFromSystem && xml.RouteData.RequestFromSystem.SystemID
+
+  return systemId?.trim()
+}
+
 const readMessage = async (message: ReceivedMessage): PromiseResult<AuditLog> => {
   const xml = await parseXml<DeliveryMessage>(message.messageXml).catch((error: Error) => error)
 
@@ -51,6 +57,7 @@ const readMessage = async (message: ReceivedMessage): PromiseResult<AuditLog> =>
 
   const auditLog = new AuditLog(externalCorrelationId, new Date(message.receivedDate), message.messageXml)
   auditLog.caseId = caseId
+  auditLog.systemId = getSystemId(xml)
   auditLog.createdBy = "Incoming message handler"
   auditLog.s3Path = message.s3Path
   auditLog.externalId = message.externalId

--- a/src/shared-types/src/AuditLog.ts
+++ b/src/shared-types/src/AuditLog.ts
@@ -11,6 +11,8 @@ export default class AuditLog {
 
   public caseId: string
 
+  public systemId: string
+
   public events: AuditLogEvent[] = []
 
   public automationReport: AutomationReport = { events: [] }

--- a/src/shared/src/utils/xml.test.ts
+++ b/src/shared/src/utils/xml.test.ts
@@ -21,6 +21,14 @@ describe("xml", () => {
 
       expect(xml.name).toBe("Bob")
     })
+
+    it("should parse the xml into an object and ignore attributes", async () => {
+      type Person = { name: string }
+      const personXml = `<name attr="value">Bob</name>`
+      const xml = await parseXml<Person>(personXml)
+
+      expect(xml.name).toBe("Bob")
+    })
   })
 
   describe("hasRootElement", () => {

--- a/src/shared/src/utils/xml.ts
+++ b/src/shared/src/utils/xml.ts
@@ -12,7 +12,8 @@ export const parseXml = <T>(xml: string): Promise<T> => {
       {
         tagNameProcessors: [stripNamespaces],
         explicitArray: false,
-        trim: true
+        trim: true,
+        ignoreAttrs: true
       },
       (error, result) => {
         if (error) {


### PR DESCRIPTION
This PR updates the incoming message handler to extract `systemId` from the message XML and store it in the AuditLog record.