### PR TITLE
Update readMessage to get systemId from DataStream

### DIFF
--- a/src/incoming-message-handler/src/entities/DeliveryMessage.ts
+++ b/src/incoming-message-handler/src/entities/DeliveryMessage.ts
@@ -5,6 +5,7 @@ type DeliveryMessage = {
       SystemID: string
     }
     DataStream: {
+      System: string
       DataStreamContent: {
         ResultedCaseMessage: {
           Session: {

--- a/src/incoming-message-handler/src/use-cases/readMessage.test.ts
+++ b/src/incoming-message-handler/src/use-cases/readMessage.test.ts
@@ -21,11 +21,11 @@ const expectedMessage = formatXml(`
     <CorrelationID>
       ${expectedExternalCorrelationId}
     </CorrelationID>
-    <SystemID>
-      ${expectedSystemId}
-    </SystemID>
   </RequestFromSystem>
 	<DataStream>
+    <System>
+      ${expectedSystemId}
+    </System>
     <DataStreamContent>
       <DC:ResultedCaseMessage xmlns:DC="http://www.dca.gov.uk/xmlschemas/libra" Flow='ResultedCasesForThePolice' Interface='LibraStandardProsecutorPolice' SchemaVersion='0.6g'>
         <DC:Session>

--- a/src/incoming-message-handler/src/use-cases/readMessage.ts
+++ b/src/incoming-message-handler/src/use-cases/readMessage.ts
@@ -51,7 +51,7 @@ const readMessage = async (message: ReceivedMessage): PromiseResult<AuditLog> =>
 
   const auditLog = new AuditLog(externalCorrelationId, new Date(message.receivedDate))
   auditLog.caseId = caseId
-  auditLog.systemId = xml.RouteData?.RequestFromSystem?.SystemID?.trim()
+  auditLog.systemId = xml.RouteData?.DataStream?.System?.trim()
   auditLog.createdBy = "Incoming message handler"
   auditLog.s3Path = message.s3Path
   auditLog.externalId = message.externalId


### PR DESCRIPTION
This PR updates `readMessage` use case to get the `systemId` from the correct XML path (RouteData/DataStream/System)