### PR TITLE
Move eslint config from package.json to eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,8 +57,11 @@ module.exports = {
     },
     {
       files: ["**/*.tsx"],
+      plugins: ["react-hooks"],
       rules: {
-        "@typescript-eslint/explicit-module-boundary-types": ["off"]
+        "@typescript-eslint/explicit-module-boundary-types": ["off"],
+        "react-hooks/rules-of-hooks": "error",
+        "react-hooks/exhaustive-deps": "warn"
       }
     },
     {

--- a/src/audit-log-portal/package.json
+++ b/src/audit-log-portal/package.json
@@ -74,14 +74,5 @@
   },
   "msw": {
     "workerDirectory": "public"
-  },
-  "eslintConfig": {
-    "plugins": [
-      "react-hooks"
-    ],
-    "rules": {
-      "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn"
-    }
   }
 }


### PR DESCRIPTION
This PR moves the ESLint config in `audit-log-portal/package.json` to the `.eslintrc.js` in the root.

It seems the ESLint config in the root was being overridden by the config in the `package.json`.