### PR TITLE
Update AuditLogEvent to replace truncated attribute value with a fixed text

### DIFF
--- a/src/shared-types/src/AuditLogEvent.test.ts
+++ b/src/shared-types/src/AuditLogEvent.test.ts
@@ -15,8 +15,8 @@ describe("AuditLogEvent", () => {
       const log = new AuditLogEvent(defaultOptions)
       log.addAttribute("test", value)
       const attrValue: string = log.attributes.test as string
-      expect(attrValue).toHaveLength(1000)
-      expect(attrValue.endsWith("xxx...[truncated]")).toBeTruthy()
+      expect(attrValue).toHaveLength(27)
+      expect(attrValue).toBe("See original log file in S3")
     })
 
     it("should not truncate the attribute if the text is not too long", () => {

--- a/src/shared-types/src/AuditLogEvent.ts
+++ b/src/shared-types/src/AuditLogEvent.ts
@@ -23,11 +23,7 @@ export default class AuditLogEvent {
 
   addAttribute(name: string, value: unknown): void {
     const maxStringLength = 1000
-    const truncateString = "...[truncated]"
-    let valueToAdd = value
-    if (typeof valueToAdd === "string" && valueToAdd.length > maxStringLength) {
-      valueToAdd = valueToAdd.substring(0, maxStringLength - truncateString.length) + truncateString
-    }
-    this.attributes[name] = valueToAdd
+    this.attributes[name] =
+      typeof value === "string" && value.length > maxStringLength ? "See original log file in S3" : value
   }
 }


### PR DESCRIPTION
This PR updates the` addAttribute` function in the `AuditLogEvent` class to use a fixed string instead of truncating the attribute value.