### PR TITLE
Fix message hash exists error in event handler step function

### DIFF
--- a/src/event-handler/src/use-cases/CreateEventUseCase.test.ts
+++ b/src/event-handler/src/use-cases/CreateEventUseCase.test.ts
@@ -2,22 +2,21 @@ import { FakeApiClient } from "shared-testing"
 import type { AuditLogEvent } from "shared-types"
 import CreateEventUseCase from "./CreateEventUseCase"
 
+const fakeApiClient = new FakeApiClient()
+const useCase = new CreateEventUseCase(fakeApiClient)
+
 describe("CreateEventUseCase", () => {
-  const fakeApiClient = new FakeApiClient()
+  beforeEach(() => {
+    fakeApiClient.reset()
+  })
 
   it("should be successful when event is created successfully", async () => {
-    const useCase = new CreateEventUseCase(fakeApiClient)
-
-    fakeApiClient.reset()
     const result = await useCase.execute("DummyMessageId", {} as AuditLogEvent)
 
     expect(result).toBeUndefined()
   })
 
   it("should be successful when event does not have messageId", async () => {
-    const useCase = new CreateEventUseCase(fakeApiClient)
-
-    fakeApiClient.reset()
     const result = await useCase.execute("", {} as AuditLogEvent)
 
     expect(result).toBeUndefined()
@@ -25,9 +24,6 @@ describe("CreateEventUseCase", () => {
 
   it("should fail when audit log API fails to create message", async () => {
     const expectedError = new Error("Create audit log failed")
-    const useCase = new CreateEventUseCase(fakeApiClient)
-
-    fakeApiClient.reset()
     fakeApiClient.shouldReturnError(expectedError, ["createAuditLog"])
     const result = await useCase.execute("DummyMessageId", {} as AuditLogEvent)
 
@@ -36,12 +32,25 @@ describe("CreateEventUseCase", () => {
 
   it("should fail when audit log API fails to create event", async () => {
     const expectedError = new Error("Create event failed")
-    const useCase = new CreateEventUseCase(fakeApiClient)
-
-    fakeApiClient.reset()
     fakeApiClient.shouldReturnError(expectedError, ["createEvent"])
     const result = await useCase.execute("DummyMessageId", {} as AuditLogEvent)
 
     expect(result).toBeError(expectedError.message)
+  })
+
+  it("should be successful when create audit log returns message id exists error", async () => {
+    const expectedError = new Error("A message with Id DUMMY already exists")
+    fakeApiClient.shouldReturnError(expectedError, ["createAuditLog"])
+    const result = await useCase.execute("ExistingMessageId", {} as AuditLogEvent)
+
+    expect(result).toBeUndefined()
+  })
+
+  it("should be successful when create audit log returns message hash exists error", async () => {
+    const expectedError = new Error("Error creating audit log: Message hash already exists")
+    fakeApiClient.shouldReturnError(expectedError, ["createAuditLog"])
+    const result = await useCase.execute("DummyMessageId", {} as AuditLogEvent)
+
+    expect(result).toBeUndefined()
   })
 })

--- a/src/event-handler/src/use-cases/CreateEventUseCase.ts
+++ b/src/event-handler/src/use-cases/CreateEventUseCase.ts
@@ -23,7 +23,8 @@ export default class {
 
     if (
       isError(createAuditLogResult) &&
-      /A message with Id .+ already exists/i.test(createAuditLogResult.message) === false
+      /A message with Id .+ already exists/i.test(createAuditLogResult.message) === false &&
+      /Message hash already exists/i.test(createAuditLogResult.message) === false
     ) {
       return createAuditLogResult
     }


### PR DESCRIPTION
Event handler state machine fails to store events for message IDs that do not exist in DynamoDB table.

Following steps are done by event handler when processing an event:
- Checks if message ID has value
- Tries creating an audit log item with the message ID passed. It also uses the same value for message hash. (messageHash = messageId)
  - If it **successfully** creates audit log record, then it stores the event against that audit log record
  - If it fails to create audit log item because **message ID already exists**, then it assumes that the record exists and tries to store the event against the existing audit log record.

However, the logic wasn't checking for the message hash existence error. This PR adds the following to the above steps:
  - If it fails to create audit log item because **message hash already exists**, then it assumes that the record exists and tries to store the event against the existing audit log record.

Here is the error we receive in step function execution:
<img width="890" alt="image" src="https://user-images.githubusercontent.com/7821490/163023867-cc472326-7312-4958-98b6-a30c0450bfb9.png">
