### PR TITLE
Update create event API handler to return error when message version is invalid

### DIFF
--- a/src/audit-log-api/src/handlers/createAuditLogEvent.test.ts
+++ b/src/audit-log-api/src/handlers/createAuditLogEvent.test.ts
@@ -79,4 +79,20 @@ describe("createAuditLogEvent()", () => {
     expect(actualResponse.statusCode).toBe(HttpStatusCode.internalServerError)
     expect(actualResponse.body).toBe(expectedMessage)
   })
+
+  it("should respond with an Internal Server Error status when an the message version is different", async () => {
+    const expectedMessage = "Expected Message"
+    jest.spyOn(CreateAuditLogEventUseCase.prototype, "create").mockReturnValue(
+      Promise.resolve({
+        resultType: "invalidVersion",
+        resultDescription: expectedMessage
+      })
+    )
+
+    const event = createHandlerEvent()
+    const actualResponse = await createAuditLogEvent(event)
+
+    expect(actualResponse.statusCode).toBe(HttpStatusCode.conflict)
+    expect(actualResponse.body).toBe(expectedMessage)
+  })
 })

--- a/src/audit-log-api/src/handlers/createAuditLogEvent.test.ts
+++ b/src/audit-log-api/src/handlers/createAuditLogEvent.test.ts
@@ -80,7 +80,7 @@ describe("createAuditLogEvent()", () => {
     expect(actualResponse.body).toBe(expectedMessage)
   })
 
-  it("should respond with an Internal Server Error status when an the message version is different", async () => {
+  it("should respond with a Conflict status when an the message version is different", async () => {
     const expectedMessage = "Expected Message"
     jest.spyOn(CreateAuditLogEventUseCase.prototype, "create").mockReturnValue(
       Promise.resolve({

--- a/src/audit-log-api/src/handlers/createAuditLogEvent.ts
+++ b/src/audit-log-api/src/handlers/createAuditLogEvent.ts
@@ -42,6 +42,14 @@ export default async function createAuditLogEvent(event: APIGatewayProxyEvent): 
     })
   }
 
+  if (result.resultType === "invalidVersion") {
+    logger.error(`Message version is invalid: ${result.resultDescription}`)
+    return createJsonApiResult({
+      statusCode: HttpStatusCode.conflict,
+      body: result.resultDescription
+    })
+  }
+
   if (result.resultType === "error") {
     logger.error(`Error creating audit log: ${result.resultDescription}`)
     return createJsonApiResult({


### PR DESCRIPTION
Create audit log event API handler was not returning an error when the message version was invalid. It was returning HTTP status code 201 when DynamoDB wasn't updating the record due to a different version number passed.