### PR TITLE
BICAWS-1649: Small improvements to shared testing library

### DIFF
--- a/src/audit-log-api/src/use-cases/CreateRetryingEventUseCase.test.ts
+++ b/src/audit-log-api/src/use-cases/CreateRetryingEventUseCase.test.ts
@@ -13,7 +13,7 @@ it("should create event when message id exists in the database", async () => {
 
 it("should return error when API returns error", async () => {
   const expectedError = new Error("Expected Error Message")
-  fakeApiClient.shouldReturnError(expectedError)
+  fakeApiClient.setErrorReturnedByFunctions(expectedError)
 
   const result = await useCase.create("Message ID")
 

--- a/src/event-handler/src/use-cases/CreateEventUseCase.test.ts
+++ b/src/event-handler/src/use-cases/CreateEventUseCase.test.ts
@@ -24,7 +24,7 @@ describe("CreateEventUseCase", () => {
 
   it("should fail when audit log API fails to create message", async () => {
     const expectedError = new Error("Create audit log failed")
-    fakeApiClient.shouldReturnError(expectedError, ["createAuditLog"])
+    fakeApiClient.setErrorReturnedByFunctions(expectedError, ["createAuditLog"])
     const result = await useCase.execute("DummyMessageId", {} as AuditLogEvent)
 
     expect(result).toBeError(expectedError.message)
@@ -32,7 +32,7 @@ describe("CreateEventUseCase", () => {
 
   it("should fail when audit log API fails to create event", async () => {
     const expectedError = new Error("Create event failed")
-    fakeApiClient.shouldReturnError(expectedError, ["createEvent"])
+    fakeApiClient.setErrorReturnedByFunctions(expectedError, ["createEvent"])
     const result = await useCase.execute("DummyMessageId", {} as AuditLogEvent)
 
     expect(result).toBeError(expectedError.message)
@@ -40,7 +40,7 @@ describe("CreateEventUseCase", () => {
 
   it("should be successful when create audit log returns message id exists error", async () => {
     const expectedError = new Error("A message with Id DUMMY already exists")
-    fakeApiClient.shouldReturnError(expectedError, ["createAuditLog"])
+    fakeApiClient.setErrorReturnedByFunctions(expectedError, ["createAuditLog"])
     const result = await useCase.execute("ExistingMessageId", {} as AuditLogEvent)
 
     expect(result).toBeUndefined()
@@ -48,7 +48,7 @@ describe("CreateEventUseCase", () => {
 
   it("should be successful when create audit log returns message hash exists error", async () => {
     const expectedError = new Error("Error creating audit log: Message hash already exists")
-    fakeApiClient.shouldReturnError(expectedError, ["createAuditLog"])
+    fakeApiClient.setErrorReturnedByFunctions(expectedError, ["createAuditLog"])
     const result = await useCase.execute("DummyMessageId", {} as AuditLogEvent)
 
     expect(result).toBeUndefined()


### PR DESCRIPTION
Small improvements to shared testing library. Broke this out into its own PR to help keep sizes smol.

* Renamed `shouldReturnError` functions (only for `FakeAPIClient`) to `setErrorReturnedByFunctions`
* Added `setErrorReturnedByFunctionsAfterNCalls` function for future PR