### PR TITLE
Update SanitiseAuditLogUseCase to remove PII from all events

### DIFF
--- a/src/audit-log-api/src/use-cases/SanitisAuditLogUseCase.test.ts
+++ b/src/audit-log-api/src/use-cases/SanitisAuditLogUseCase.test.ts
@@ -29,6 +29,8 @@ const createBichardAuditLogEvent = () => {
 
 const message = new AuditLog("External Correlation ID", new Date(), "Dummy hash")
 message.events = [createBichardAuditLogEvent()]
+message.automationReport.events = [createBichardAuditLogEvent()]
+message.topExceptionsReport.events = [createBichardAuditLogEvent()]
 
 afterAll(() => {
   MockDate.reset()
@@ -39,9 +41,18 @@ it("should remove attributes containing PII", async () => {
 
   expect(sanitiseAuditLogResult).toNotBeError()
   const actualMessage = sanitiseAuditLogResult as AuditLog
+
   const attributes = actualMessage?.events.find((event) => "s3Path" in event)?.attributes ?? {}
   expect(Object.keys(attributes)).toHaveLength(1)
   expect(attributes["Trigger 2 Details"]).toBe("TRPR0004")
+
+  const automationReportAttributes = actualMessage?.automationReport.events[0].attributes ?? {}
+  expect(Object.keys(automationReportAttributes)).toHaveLength(1)
+  expect(automationReportAttributes["Trigger 2 Details"]).toBe("TRPR0004")
+
+  const topExceptionsReportAttributes = actualMessage?.topExceptionsReport.events[0].attributes ?? {}
+  expect(Object.keys(topExceptionsReportAttributes)).toHaveLength(1)
+  expect(topExceptionsReportAttributes["Trigger 2 Details"]).toBe("TRPR0004")
 })
 
 it("should update the AuditLog  status to Sanitised", async () => {

--- a/src/audit-log-api/src/use-cases/SanitisAuditLogUseCase.ts
+++ b/src/audit-log-api/src/use-cases/SanitisAuditLogUseCase.ts
@@ -5,14 +5,16 @@ export default class SanitiseAuditLogUseCase {
   constructor(private readonly auditLogDynamoGateway: AuditLogDynamoGateway) {}
 
   call(auditLog: AuditLog): PromiseResult<AuditLog> {
-    for (const auditLogEvent of auditLog.events) {
-      delete auditLogEvent.attributes.AmendedPNCUpdateDataset
-      delete auditLogEvent.attributes.AmendedHearingOutcome
-      delete auditLogEvent.attributes["Original Hearing Outcome / PNC Update Dataset"]
-      delete auditLogEvent.attributes.OriginalHearingOutcome
-      delete auditLogEvent.attributes.OriginalPNCUpdateDataset
-      delete auditLogEvent.attributes.PNCUpdateDataset
-    }
+    ;[auditLog.events, auditLog.automationReport.events, auditLog.topExceptionsReport.events].forEach((events) => {
+      for (const auditLogEvent of events) {
+        delete auditLogEvent.attributes.AmendedPNCUpdateDataset
+        delete auditLogEvent.attributes.AmendedHearingOutcome
+        delete auditLogEvent.attributes["Original Hearing Outcome / PNC Update Dataset"]
+        delete auditLogEvent.attributes.OriginalHearingOutcome
+        delete auditLogEvent.attributes.OriginalPNCUpdateDataset
+        delete auditLogEvent.attributes.PNCUpdateDataset
+      }
+    })
 
     auditLog.events.push(
       new AuditLogEvent({


### PR DESCRIPTION
### Context 
In the previous implementation, we missed sanitising some events audit-log table, `automationReport.events` and `topExceptionsReport.events` can also contain PII 
```
{
 "messageId": "*****",
 "automationReport": {
  "events": [],
  }
 "topExceptionsReport": {
  "events": []
  },
},
```