### PR TITLE
Fix audit log archival

### DIFF
--- a/src/add-archival-events/package-lock.json
+++ b/src/add-archival-events/package-lock.json
@@ -49,7 +49,8 @@
         "shared-types": "file:../shared-types",
         "stompit": "^1.0.0",
         "uuid": "^8.3.2",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.4.23",
+        "zlib": "^1.0.5"
       },
       "devDependencies": {
         "@types/jest": "^27.4.0",
@@ -17068,7 +17069,8 @@
         "ts-jest": "^27.1.3",
         "typescript": "^4.5.5",
         "uuid": "^8.3.2",
-        "xml2js": "^0.4.23"
+        "xml2js": "^0.4.23",
+        "zlib": "^1.0.5"
       }
     },
     "shared-testing": {

--- a/src/add-archival-events/src/api.ts
+++ b/src/add-archival-events/src/api.ts
@@ -3,78 +3,79 @@ import type { ApiClient } from "shared-types"
 import { AuditLog, AuditLogEvent, isError, EventType } from "shared-types"
 import type { BichardRecord } from "./db"
 
-const hasArchivalEvent = (auditLog: AuditLog, recordId: number): boolean =>
-  auditLog.events.filter((event) => {
-    return (
-      event.eventType === EventType.ErrorRecordArchival &&
-      event.category === "information" &&
-      (event.attributes["Record ID"] || "") === recordId
-    )
-  }).length > 0
+export default class ArchivalEventsApiClient {
+  constructor(private api: ApiClient) {}
 
-const createAuditLog = async (api: ApiClient, messageId: string, archivedAt: Date): Promise<boolean> => {
-  const message = {
-    ...new AuditLog(messageId, archivedAt, messageId, messageId), // We don't have the message XML to compute the message hash
-    messageId,
-    caseId: "Unknown",
-    createdBy: "Add Archival Events"
-  }
-  const createEventResult = await api.createAuditLog(message)
-  if (isError(createEventResult)) {
-    logger.error({ message: "Failed to create audit log for record", messageId: messageId })
-  }
+  public isRecordInAuditLog = async (bichardRecord: BichardRecord): Promise<{ exists: boolean; err: boolean }> => {
+    logger.debug({ message: "Retreiving message from audit log", record: bichardRecord })
+    const messageResult = await this.api.getMessage(bichardRecord.messageId)
 
-  return isError(createEventResult)
-}
-
-export const isRecordInAuditLog = async (
-  api: ApiClient,
-  bichardRecord: BichardRecord
-): Promise<{ exists: boolean; err: boolean }> => {
-  logger.debug({ message: "Retreiving message from audit log", record: bichardRecord })
-  const messageResult = await api.getMessage(bichardRecord.messageId)
-
-  if (isError(messageResult)) {
-    logger.error({
-      message: "Failed to retrieve message from audit log API",
-      reason: messageResult.message,
-      record: bichardRecord
-    })
-    return { exists: false, err: true }
-  }
-
-  // Create audit log message if one does not already exist
-  if (messageResult === undefined) {
-    const err = await createAuditLog(api, bichardRecord.messageId, bichardRecord.archivedAt)
-    if (err) {
-      logger.error({ message: "Failed to create audit log for record", messageId: bichardRecord.messageId })
+    if (isError(messageResult)) {
+      logger.error({
+        message: "Failed to retrieve message from audit log API",
+        reason: messageResult.message,
+        record: bichardRecord
+      })
+      return { exists: false, err: true }
     }
-    return { exists: false, err }
+
+    // Create audit log message if one does not already exist
+    if (!messageResult) {
+      const err = await this.createAuditLog(bichardRecord.messageId, bichardRecord.archivedAt)
+      if (err) {
+        logger.error({ message: "Failed to create audit log for record", messageId: bichardRecord.messageId })
+      }
+      return { exists: false, err }
+    }
+
+    return { exists: this.hasArchivalEvent(messageResult, bichardRecord.recordId), err: false }
   }
 
-  return { exists: hasArchivalEvent(messageResult, bichardRecord.recordId), err: false }
-}
-
-export const createArchivalEventInAuditLog = async (api: ApiClient, bichardRecord: BichardRecord): Promise<boolean> => {
-  const auditLogEvent = new AuditLogEvent({
-    eventSource: bichardRecord.archivedBy,
-    category: "information",
-    eventType: EventType.ErrorRecordArchival,
-    timestamp: bichardRecord.archivedAt
-  })
-  auditLogEvent.addAttribute("Record ID", bichardRecord.recordId)
-
-  logger.debug({ message: "Audit logging the archival of an error record", record: bichardRecord })
-  const response = await api.createEvent(bichardRecord.messageId, auditLogEvent)
-
-  if (isError(response)) {
-    logger.error({
-      message: "Error marking record as archived in audit log",
-      reason: response.message,
-      record: bichardRecord
+  public createArchivalEventInAuditLog = async (bichardRecord: BichardRecord): Promise<boolean> => {
+    const auditLogEvent = new AuditLogEvent({
+      eventSource: bichardRecord.archivedBy,
+      category: "information",
+      eventType: EventType.ErrorRecordArchival,
+      timestamp: bichardRecord.archivedAt
     })
-    return true
+    auditLogEvent.addAttribute("Record ID", bichardRecord.recordId)
+
+    logger.debug({ message: "Audit logging the archival of an error record", record: bichardRecord })
+    const response = await this.api.createEvent(bichardRecord.messageId, auditLogEvent)
+
+    if (isError(response)) {
+      logger.error({
+        message: "Error marking record as archived in audit log",
+        reason: response.message,
+        record: bichardRecord
+      })
+      return true
+    }
+
+    return isError(response)
   }
 
-  return isError(response)
+  private createAuditLog = async (messageId: string, archivedAt: Date): Promise<boolean> => {
+    const message = {
+      ...new AuditLog(messageId, archivedAt, messageId, messageId), // We don't have the message XML to compute the message hash
+      messageId,
+      caseId: "Unknown",
+      createdBy: "Add Archival Events"
+    }
+    const createEventResult = await this.api.createAuditLog(message)
+    if (isError(createEventResult)) {
+      logger.error({ message: "Failed to create audit log for record", messageId: messageId })
+    }
+
+    return isError(createEventResult)
+  }
+
+  private hasArchivalEvent = (auditLog: AuditLog, recordId: number): boolean =>
+    auditLog.events.filter((event: AuditLogEvent) => {
+      return (
+        event.eventType === EventType.ErrorRecordArchival &&
+        event.category === "information" &&
+        (event.attributes["Record ID"] || "") === recordId
+      )
+    }).length > 0
 }

--- a/src/add-archival-events/src/db.ts
+++ b/src/add-archival-events/src/db.ts
@@ -23,7 +23,7 @@ export type DatabaseRow = {
 // Produces the string "$1, $2, $3..." for the given range
 const wherePlaceholderForRange = (range: number) => [...Array(range).keys()].map((x) => `$${x + 1}`).join(", ")
 
-export default class DatabaseClient {
+export class DatabaseClient {
   private postgres: Client
 
   constructor(

--- a/src/add-archival-events/src/index.ts
+++ b/src/add-archival-events/src/index.ts
@@ -1,7 +1,7 @@
 import { AuditLogApiClient, logger } from "shared"
 import getConfig from "./config"
-import DatabaseClient from "./db"
-import { addBichardRecordsToAuditLog } from "./addArchivalEvents"
+import { DatabaseClient } from "./db"
+import AddArchivalEvents from "./addArchivalEvents"
 
 export default async function addArchivalEvents(): Promise<void> {
   const config = getConfig()
@@ -16,12 +16,13 @@ export default async function addArchivalEvents(): Promise<void> {
     config.archiveGroupLimit
   )
   const auditLogApi = new AuditLogApiClient(config.apiUrl, config.apiKey)
+  const addArchialEvents = new AddArchivalEvents(auditLogApi, db)
 
   await db.connect()
 
   try {
     await db.markUnmarkedGroupsCompleted()
-    await addBichardRecordsToAuditLog(db, auditLogApi)
+    await addArchialEvents.addBichardRecordsToAuditLog()
   } catch (error) {
     logger.error(error as Error)
   } finally {

--- a/src/shared-types/src/AuditLog.ts
+++ b/src/shared-types/src/AuditLog.ts
@@ -39,8 +39,13 @@ export default class AuditLog {
 
   public readonly version = 0
 
-  constructor(public readonly externalCorrelationId: string, receivedDate: Date, public readonly messageHash: string) {
-    this.messageId = uuid()
+  constructor(
+    public readonly externalCorrelationId: string,
+    receivedDate: Date,
+    public readonly messageHash: string,
+    messageId?: string
+  ) {
+    this.messageId = messageId ?? uuid()
     this.receivedDate = receivedDate.toISOString()
   }
 }


### PR DESCRIPTION
Fix issue with `add-archival-events` lambda where legacy records can't be added as events to an audit log due to them no having an audit log created for them.