### PR TITLE
Update incoming message handler to remove duplicate message from S3

### DIFF
--- a/src/incoming-message-handler/scripts/state-machine.json.tpl
+++ b/src/incoming-message-handler/scripts/state-machine.json.tpl
@@ -27,7 +27,7 @@
               "BooleanEquals": false
             }
           ],
-          "Next": "Message validation failed"
+          "Next": "Delete invalid message from S3"
         },
         {
           "Variable": "$.validationResult",
@@ -36,9 +36,20 @@
         }
       ]
     },
-    "Message validation failed": {
-      "Type": "Pass",
-      "End": true
+    "Delete invalid message from S3": {
+      "Type": "Task",
+      "End": true,
+      "Parameters": {
+        "Bucket.$": "$.bucketName",
+        "Key.$": "$.s3Path"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:s3:deleteObject",
+      "Retry": [{
+        "ErrorEquals": ["States.ALL"],
+        "IntervalSeconds": 180,
+        "MaxAttempts": 99999999,
+        "BackoffRate": 1.1
+      }]
     },
     "Send to Bichard": {
       "Type": "Task",


### PR DESCRIPTION
This PR:
- Adds a new step to the incoming message handler state machine to delete the duplicate message from the S3 bucket
- Updates store message handler to return the S3 key and bucket if validation failed for the next step in the state machine to delete the object from S3