### PR TITLE
Populate sanitisation fields for audit log messages

### DIFF
--- a/src/audit-log-api/serverless.yml
+++ b/src/audit-log-api/serverless.yml
@@ -92,6 +92,10 @@ resources:
             AttributeType: S
           - AttributeName: caseId
             AttributeType: S
+          - AttributeName: isSanitised
+            AttributeType: N
+          - AttributeName: nextSanitiseCheck
+            AttributeType: S
         KeySchema:
           - AttributeName: messageId
             KeyType: HASH
@@ -140,6 +144,17 @@ resources:
             KeySchema:
               - AttributeName: caseId
                 KeyType: HASH
+            Projection:
+              ProjectionType: "ALL"
+            ProvisionedThroughput:
+              ReadCapacityUnits: 1
+              WriteCapacityUnits: 1
+          - IndexName: isSanitisedIndex
+            KeySchema:
+              - AttributeName: isSanitised
+                KeyType: HASH
+              - AttributeName: nextSanitiseCheck
+                KeyType: RANGE
             Projection:
               ProjectionType: "ALL"
             ProvisionedThroughput:

--- a/src/audit-log-api/src/use-cases/validateCreateAuditLog.ts
+++ b/src/audit-log-api/src/use-cases/validateCreateAuditLog.ts
@@ -106,7 +106,9 @@ export default async (auditLog: AuditLog, dynamoGateway: AuditLogDynamoGateway):
     events: [],
     automationReport: { events: [] },
     topExceptionsReport: { events: [] },
-    messageHash
+    messageHash,
+    isSanitised: 0,
+    nextSanitiseCheck: formattedReceivedDate || receivedDate
   }
 
   return {

--- a/src/shared-types/src/AuditLog.test.ts
+++ b/src/shared-types/src/AuditLog.test.ts
@@ -1,0 +1,11 @@
+import { AuditLog } from "."
+
+describe("AuditLog", () => {
+  describe("constructor", () => {
+    it("should populate the sanitisation fields", () => {
+      const auditLog = new AuditLog("externalCorrelationId", new Date("2021-01-01T00:00:00.000Z"), "messageHash")
+      expect(auditLog.isSanitised).toBe(0)
+      expect(auditLog.nextSanitiseCheck).toBe("2021-01-01T00:00:00.000Z")
+    })
+  })
+})

--- a/src/shared-types/src/AuditLog.ts
+++ b/src/shared-types/src/AuditLog.ts
@@ -11,7 +11,9 @@ export default class AuditLog {
 
   public errorRecordArchivalDate?: string
 
-  public sanitisedDate?: string
+  public isSanitised = 0
+
+  public nextSanitiseCheck: string
 
   public caseId: string
 
@@ -47,5 +49,6 @@ export default class AuditLog {
   ) {
     this.messageId = messageId ?? uuid()
     this.receivedDate = receivedDate.toISOString()
+    this.nextSanitiseCheck = this.receivedDate
   }
 }

--- a/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.integration.test.ts
+++ b/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.integration.test.ts
@@ -413,7 +413,7 @@ describe("AuditLogDynamoGateway", () => {
       expect(actualMessage).toNotBeError()
 
       const actualAuditLog = actualMessage as AuditLog
-      expect(actualAuditLog.sanitisedDate).toBe(expectedEvent.timestamp)
+      expect(actualAuditLog.isSanitised).toBeTruthy()
       expect(actualAuditLog.status).toBe(AuditLogStatus.processing)
     })
   })
@@ -702,7 +702,8 @@ describe("AuditLogDynamoGateway", () => {
     it("should not change the status and should set error record archival date", async () => {
       const expectedEvent = createAuditLogEvent("information", new Date(), EventType.ErrorRecordArchival)
 
-      const message = new AuditLog("one", new Date(), `dummy hash`)
+      const now = new Date()
+      const message = new AuditLog("one", now, `dummy hash`)
 
       await gateway.create(message)
 
@@ -715,7 +716,10 @@ describe("AuditLogDynamoGateway", () => {
       expect(actualMessage).toNotBeError()
 
       const actualAuditLog = actualMessage as AuditLog
-      expect(actualAuditLog).not.toHaveProperty("sanitisedDate")
+      expect(actualAuditLog).toHaveProperty("isSanitised")
+      expect(actualAuditLog.isSanitised).toBeFalsy()
+      expect(actualAuditLog).toHaveProperty("nextSanitiseCheck")
+      expect(actualAuditLog.nextSanitiseCheck).toBe(now.toISOString())
       expect(actualAuditLog.errorRecordArchivalDate).toBe(expectedEvent.timestamp)
       expect(actualAuditLog.status).toBe(AuditLogStatus.processing)
     })
@@ -723,7 +727,8 @@ describe("AuditLogDynamoGateway", () => {
     it("should not change the status and should set sanitised date", async () => {
       const expectedEvent = createAuditLogEvent("information", new Date(), EventType.SanitisedMessage)
 
-      const message = new AuditLog("one", new Date(), `dummy hash`)
+      const now = new Date()
+      const message = new AuditLog("one", now, `dummy hash`)
 
       await gateway.create(message)
 
@@ -737,7 +742,9 @@ describe("AuditLogDynamoGateway", () => {
 
       const actualAuditLog = actualMessage as AuditLog
       expect(actualAuditLog).not.toHaveProperty("errorRecordArchivalDate")
-      expect(actualAuditLog.sanitisedDate).toBe(expectedEvent.timestamp)
+      expect(actualAuditLog).toHaveProperty("isSanitised")
+      expect(actualAuditLog.isSanitised).toBeTruthy()
+      expect(actualAuditLog).toHaveProperty("nextSanitiseCheck")
       expect(actualAuditLog.status).toBe(AuditLogStatus.processing)
     })
 

--- a/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
+++ b/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
@@ -39,8 +39,7 @@ export default class AwsAuditLogDynamoGateway extends DynamoGateway implements A
     message.errorRecordArchivalDate =
       message.errorRecordArchivalDate ??
       message.events.find((event) => event.eventType === EventType.ErrorRecordArchival)?.timestamp
-    message.sanitisedDate =
-      message.sanitisedDate ?? message.events.find((event) => event.eventType === EventType.SanitisedMessage)?.timestamp
+    message.isSanitised = message.events.find((event) => event.eventType === EventType.SanitisedMessage) ? 1 : 0
 
     const result = await this.updateOne(this.tableName, message, "messageId", message.version)
 
@@ -209,9 +208,9 @@ export default class AwsAuditLogDynamoGateway extends DynamoGateway implements A
       updateExpressionValues[":errorRecordArchivalDate"] = event.timestamp
       updateExpression += ",#errorRecordArchivalDate = :errorRecordArchivalDate"
     } else if (event.eventType === EventType.SanitisedMessage) {
-      expressionAttributeNames["#sanitisedDate"] = "sanitisedDate"
-      updateExpressionValues[":sanitisedDate"] = event.timestamp
-      updateExpression += ",#sanitisedDate = :sanitisedDate"
+      expressionAttributeNames["#isSanitised"] = "isSanitised"
+      updateExpressionValues[":isSanitised"] = 1
+      updateExpression += ",#isSanitised = :isSanitised"
     } else if (event.eventType === "Retrying failed message") {
       updateExpression = `${updateExpression}, retryCount = if_not_exists(retryCounter, :zero) + :one`
       updateExpressionValues[":zero"] = 0


### PR DESCRIPTION
the lambda to sanitise old messages will rely on a couple of bookkeeping fields in dynamodb:
* `isSanitised`: a boolean representing whether this message has already been sanitised. This is stored as a number in dynamodb since [only strings, numbers and binary fields can be key attributes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/SecondaryIndexes.html)
* `nextSanitiseCheck`: a string holding an ISO timestamp of when this audit log message is next eligible to be checked for whether we should sanitise the message

This PR adds logic to populate these two fields for newly created audit log messages, and when existing audit log messages are sanitised. After deploying these changes, we will run a migration to back-fill these fields on existing audit log messages