### PR TITLE
Update CreateEventUseCase to set nextSanitiseCheck

### DIFF
--- a/src/add-archival-events/src/e2e.test.ts
+++ b/src/add-archival-events/src/e2e.test.ts
@@ -5,8 +5,8 @@ import { execute } from "lambda-local"
 import partition from "lodash.partition"
 import { Client } from "pg"
 import { AuditLogApiClient, logger, TestDynamoGateway } from "shared"
-import type { ApiClient, AuditLog } from "shared-types"
-import { AuditLogEvent, isSuccess } from "shared-types"
+import type { ApiClient } from "shared-types"
+import { AuditLog, AuditLogEvent, isSuccess } from "shared-types"
 import addArchivalEvents from "."
 
 logger.level = "debug"
@@ -22,7 +22,7 @@ const createTableSql = `
       archived_by     TEXT,
       audit_logged_at TIMESTAMP
   );
-  
+
   CREATE TABLE br7own.archive_error_list
   (
       error_id                INTEGER PRIMARY KEY,
@@ -475,38 +475,18 @@ describe("Add Error Records e2e", () => {
     )
 
     // Insert testdata into audit log
-    const messages = [
-      {
-        messageId: "message_1",
-        receivedDate: new Date("2022-05-26T12:53:55.000Z").toISOString(),
-        events: [],
-        caseId: "message_1",
-        externalCorrelationId: "message_1",
-        createdBy: "add-archival-events e2e tests",
-        messageHash: "message_1"
-      },
-      {
-        messageId: "message_2",
-        receivedDate: new Date("2022-05-26T12:53:55.000Z").toISOString(),
-        events: [],
-        caseId: "message_2",
-        externalCorrelationId: "message_2",
-        createdBy: "add-archival-events e2e tests",
-        messageHash: "message_2"
-      },
-      {
-        messageId: "message_3",
-        receivedDate: new Date("2022-05-26T12:53:55.000Z").toISOString(),
-        events: [],
-        caseId: "message_3",
-        externalCorrelationId: "message_3",
-        createdBy: "add-archival-events e2e tests",
-        messageHash: "message_3"
-      }
-    ]
-    for (const message of messages) {
-      await api.createAuditLog(message as unknown as AuditLog)
-    }
+    await Promise.all(
+      [1, 2, 3].map((messageNumber) => {
+        const messageId = `message_${messageNumber}`
+        const message = {
+          ...new AuditLog(messageId, new Date("2022-05-26T12:53:55.000Z"), messageId, messageId),
+          caseId: messageId,
+          createdBy: "add-archival-events e2e tests"
+        } as unknown as AuditLog
+
+        return api.createAuditLog(message)
+      })
+    )
 
     const existingEvent2 = new AuditLogEvent({
       eventSource: "you",

--- a/src/audit-log-api/src/use-cases/validateCreateAuditLog.test.ts
+++ b/src/audit-log-api/src/use-cases/validateCreateAuditLog.test.ts
@@ -110,11 +110,12 @@ describe("validateCreateAuditLog", () => {
     const { errors, isValid } = await validateCreateAuditLog(item, dynamoGateway)
 
     expect(isValid).toBe(false)
-    expect(errors).toHaveLength(6)
+    expect(errors).toHaveLength(7)
     expect(errors).toContain("Case ID is mandatory")
     expect(errors).toContain("External Correlation ID is mandatory")
     expect(errors).toContain("Message ID is mandatory")
     expect(errors).toContain("Received date is mandatory")
+    expect(errors).toContain("Next sanitise check is mandatory")
     expect(errors).toContain("Created by is mandatory")
     expect(errors).toContain("Message hash is mandatory")
   })
@@ -126,6 +127,7 @@ describe("validateCreateAuditLog", () => {
       systemId: 3,
       externalCorrelationId: 3,
       receivedDate: "2021-10-05 12:13:14",
+      nextSanitiseCheck: "2021-10-05 12:13:14",
       createdBy: 5,
       messageHash: 6,
       s3Path: 7,
@@ -135,12 +137,13 @@ describe("validateCreateAuditLog", () => {
     const { errors, isValid } = await validateCreateAuditLog(item, dynamoGateway)
 
     expect(isValid).toBe(false)
-    expect(errors).toHaveLength(10)
+    expect(errors).toHaveLength(11)
     expect(errors).toContain("Case ID must be string")
     expect(errors).toContain("System ID must be string")
     expect(errors).toContain("External Correlation ID must be string")
     expect(errors).toContain("Message ID must be string")
     expect(errors).toContain("Received date must be ISO format")
+    expect(errors).toContain("Next sanitise check must be ISO format")
     expect(errors).toContain("Created by must be string")
     expect(errors).toContain("Message hash must be string")
     expect(errors).toContain("S3 path must be string")

--- a/src/audit-log-api/src/use-cases/validateCreateAuditLog.ts
+++ b/src/audit-log-api/src/use-cases/validateCreateAuditLog.ts
@@ -13,6 +13,7 @@ interface ValidationResult {
 export default async (auditLog: AuditLog, dynamoGateway: AuditLogDynamoGateway): Promise<ValidationResult> => {
   const errors: string[] = []
   let formattedReceivedDate = ""
+  let formattedNextSanitiseCheck = ""
   const {
     caseId,
     systemId,
@@ -23,7 +24,8 @@ export default async (auditLog: AuditLog, dynamoGateway: AuditLogDynamoGateway):
     s3Path,
     stepExecutionId,
     externalId,
-    messageHash
+    messageHash,
+    nextSanitiseCheck
   } = auditLog
 
   if (!caseId) {
@@ -54,6 +56,14 @@ export default async (auditLog: AuditLog, dynamoGateway: AuditLogDynamoGateway):
     errors.push("Received date must be ISO format")
   } else {
     formattedReceivedDate = new Date(receivedDate).toISOString()
+  }
+
+  if (!nextSanitiseCheck) {
+    errors.push("Next sanitise check is mandatory")
+  } else if (!isIsoDate(nextSanitiseCheck)) {
+    errors.push("Next sanitise check must be ISO format")
+  } else {
+    formattedNextSanitiseCheck = new Date(nextSanitiseCheck).toISOString()
   }
 
   if (!createdBy) {
@@ -97,7 +107,7 @@ export default async (auditLog: AuditLog, dynamoGateway: AuditLogDynamoGateway):
     externalId,
     stepExecutionId,
     externalCorrelationId,
-    receivedDate: formattedReceivedDate || receivedDate,
+    receivedDate: formattedReceivedDate,
     createdBy,
     status: AuditLogStatus.processing,
     lastEventType: "",
@@ -108,7 +118,7 @@ export default async (auditLog: AuditLog, dynamoGateway: AuditLogDynamoGateway):
     topExceptionsReport: { events: [] },
     messageHash,
     isSanitised: 0,
-    nextSanitiseCheck: formattedReceivedDate || receivedDate
+    nextSanitiseCheck: formattedNextSanitiseCheck
   }
 
   return {

--- a/src/event-handler/src/use-cases/CreateEventUseCase.ts
+++ b/src/event-handler/src/use-cases/CreateEventUseCase.ts
@@ -17,7 +17,8 @@ export default class {
       ...new AuditLog(messageId, new Date("1970-01-01T00:00:00.000Z"), messageId), // We don't have the message XML to compute the message hash
       messageId,
       caseId: "Unknown",
-      createdBy: "Event handler"
+      createdBy: "Event handler",
+      nextSanitiseCheck: new Date().toISOString()
     }
     const createAuditLogResult = await this.api.createAuditLog(message)
 


### PR DESCRIPTION
This PR updates event handler to set `nextSanitiseCheck` field to the current date and time. This is because by default `nextSanitiseCheck` is set to `receivedDate`, but in the event handler, we set the `receivedDate` to `1970-01-01T00:00:00.000Z` which is not a correct value for `nextSanitiseCheck`