### PR TITLE
Fix fetchUnsanitised function query order

### DIFF
--- a/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
+++ b/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
@@ -163,8 +163,7 @@ export default class AwsAuditLogDynamoGateway extends DynamoGateway implements A
     const result = await new IndexSearcher<AuditLog[]>(this, this.tableName, this.tableKey)
       .useIndex("isSanitisedIndex")
       .setIndexKeys("isSanitised", 0, "nextSanitiseCheck", new Date().toISOString(), KeyComparison.LessThanOrEqual)
-      .setAscendingOrder(true)
-      .paginate(limit, lastMessage)
+      .paginate(limit, lastMessage, true)
       .execute()
 
     if (isError(result)) {

--- a/src/shared/src/DynamoGateway/IndexSearcher.ts
+++ b/src/shared/src/DynamoGateway/IndexSearcher.ts
@@ -108,11 +108,6 @@ export default class IndexSearcher<TResult> {
     return this
   }
 
-  setAscendingOrder(isAscendingOrder: boolean): IndexSearcher<TResult> {
-    this.isAscendingOrder = isAscendingOrder
-    return this
-  }
-
   setFilter(keyName: string, keyValue: unknown, comparison: KeyComparison): IndexSearcher<TResult> {
     this.filterKeyName = keyName
     this.filterKeyValue = keyValue


### PR DESCRIPTION
This PR fixes `fetchUnsanitised` function issue with order of the items in DynamoDB query.