### PR TITLE
Update store event lambda to check if S3 object exists

### DIFF
--- a/src/event-handler/scripts/state-machine.json.tpl
+++ b/src/event-handler/scripts/state-machine.json.tpl
@@ -11,7 +11,34 @@
         "MaxAttempts": 99999999,
         "BackoffRate": 1.1
       }],
-      "Next": "Delete from S3"
+      "Next": "Validate Store Event result"
+    },
+    "Validate Store Event result": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.validationResult",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.validationResult.s3ObjectNotFound",
+              "BooleanEquals": true
+            }
+          ],
+          "Next": "S3 object not found"
+        },
+        {
+          "Variable": "$.validationResult",
+          "IsPresent": false,
+          "Next": "Delete from S3"
+        }
+      ]
+    },
+    "S3 object not found": {
+      "Type": "Pass",
+      "End": true
     },
     "Delete from S3": {
       "Type": "Task",

--- a/src/event-handler/src/e2e/EventHandlerSimulator.ts
+++ b/src/event-handler/src/e2e/EventHandlerSimulator.ts
@@ -9,6 +9,10 @@ export default class {
     this.stateMachine = new StepFunctionSimulator([storeEvent])
   }
 
+  getStoreEventOutput() {
+    return this.stateMachine.getOutput(0)
+  }
+
   async start(s3ObjectKey: string, executionId: string): Promise<void> {
     await this.stateMachine.execute({
       id: executionId,

--- a/src/event-handler/src/e2e/e2e.test.ts
+++ b/src/event-handler/src/e2e/e2e.test.ts
@@ -209,3 +209,12 @@ test("Event with no MesageId should not fail to be processed by the audit logger
 
   expect(eventHandlerResult).toNotBeError()
 })
+
+test("Event should fail the validation when S3 object does not exist", async () => {
+  // Simulating EventBridge rule for triggering state machine for the uploaded object to S3 bucket
+  const objectKey = "dummy-non-existent-s3-key"
+  const eventHandlerResult = await eventHandlerSimulator.start(objectKey!, uuid()).catch((error) => error)
+
+  expect(eventHandlerResult).toNotBeError()
+  expect(eventHandlerSimulator.getStoreEventOutput()).toStrictEqual({ validationResult: { s3ObjectNotFound: true } })
+})

--- a/src/event-handler/src/use-cases/DoesS3ObjectExist.integration.test.ts
+++ b/src/event-handler/src/use-cases/DoesS3ObjectExist.integration.test.ts
@@ -1,0 +1,66 @@
+import { setEnvironmentVariables } from "shared-testing"
+setEnvironmentVariables()
+import type { EventMessage, S3Config } from "shared-types"
+import { TestAwsS3Gateway } from "shared"
+import DoesS3ObjectExist from "./DoesS3ObjectExist"
+
+const bucketName = "auditLogEventsBucket"
+const config: S3Config = {
+  url: "http://localhost:4569",
+  region: "eu-west-2",
+  bucketName,
+  accessKeyId: "S3RVER",
+  secretAccessKey: "S3RVER"
+}
+
+const gateway = new TestAwsS3Gateway(config)
+const useCase = new DoesS3ObjectExist(gateway)
+
+describe("Check if an event object key exists in S3 bucket end-to-end", () => {
+  beforeEach(async () => {
+    await gateway.deleteAll()
+  })
+
+  test("given an event is stored in S3", async () => {
+    const s3ObjectKey = "dummy-event.json"
+    const S3ObjectContent = JSON.stringify(<EventMessage>{
+      messageData: "DummyData",
+      messageFormat: "AuditEvent",
+      eventSourceArn: "DummyArn",
+      eventSourceQueueName: "DummyQueueName"
+    })
+    await gateway.upload(s3ObjectKey, S3ObjectContent)
+
+    const payload = {
+      id: "step-execution-unique-id",
+      detail: {
+        requestParameters: {
+          key: s3ObjectKey,
+          bucketName
+        }
+      }
+    }
+
+    const result = await useCase.execute(payload)
+    expect(result).toNotBeError()
+    expect(result).toBe(true)
+  })
+
+  test("given an event is not stored in S3", async () => {
+    const s3ObjectKey = "dummy-non-existent-event.json"
+
+    const payload = {
+      id: "step-execution-unique-id",
+      detail: {
+        requestParameters: {
+          key: s3ObjectKey,
+          bucketName
+        }
+      }
+    }
+
+    const result = await useCase.execute(payload)
+    expect(result).toNotBeError()
+    expect(result).toBe(false)
+  })
+})

--- a/src/event-handler/src/use-cases/DoesS3ObjectExist.test.ts
+++ b/src/event-handler/src/use-cases/DoesS3ObjectExist.test.ts
@@ -1,0 +1,25 @@
+import { FakeS3Gateway } from "shared-testing"
+import DoesS3ObjectExist from "./DoesS3ObjectExist"
+
+const fakeGateway = new FakeS3Gateway()
+const useCase = new DoesS3ObjectExist(fakeGateway)
+
+describe("Check if an event object key exists in S3 bucket end-to-end", () => {
+  it("should return error when gateway returns error", async () => {
+    const error = new Error("Dummy error")
+    fakeGateway.shouldReturnError(error)
+
+    const payload = {
+      id: "step-execution-unique-id",
+      detail: {
+        requestParameters: {
+          key: "dummy-s3-key",
+          bucketName: "dummy-bucket"
+        }
+      }
+    }
+
+    const result = await useCase.execute(payload)
+    expect(result).toBeError("Dummy error")
+  })
+})

--- a/src/event-handler/src/use-cases/DoesS3ObjectExist.ts
+++ b/src/event-handler/src/use-cases/DoesS3ObjectExist.ts
@@ -1,0 +1,11 @@
+import type { S3PutObjectEvent, PromiseResult, S3GatewayInterface } from "shared-types"
+
+export default class DoesS3ObjectExist {
+  constructor(private s3Gateway: S3GatewayInterface) {}
+
+  execute(event: S3PutObjectEvent): PromiseResult<boolean> {
+    const { bucketName, key } = event.detail.requestParameters
+
+    return this.s3Gateway.forBucket(bucketName).doesItemExist(key)
+  }
+}

--- a/src/event-handler/src/use-cases/RetrieveEventFromS3UseCase.ts
+++ b/src/event-handler/src/use-cases/RetrieveEventFromS3UseCase.ts
@@ -1,10 +1,9 @@
 import { isError } from "shared-types"
-import type { S3PutObjectEvent, PromiseResult } from "shared-types"
-import type { AwsS3Gateway } from "shared"
+import type { S3PutObjectEvent, PromiseResult, S3GatewayInterface } from "shared-types"
 import type { EventInput } from "src/types"
 
 export default class RetrieveEventFromS3UseCase {
-  constructor(private s3Gateway: AwsS3Gateway) {}
+  constructor(private s3Gateway: S3GatewayInterface) {}
 
   async execute(event: S3PutObjectEvent): PromiseResult<EventInput> {
     const { bucketName, key } = event.detail.requestParameters

--- a/src/shared-testing/src/FakeS3Gateway.ts
+++ b/src/shared-testing/src/FakeS3Gateway.ts
@@ -31,6 +31,14 @@ export default class FakeS3Gateway implements S3GatewayInterface {
     return Promise.resolve(this.items[key])
   }
 
+  doesItemExist(key: string): PromiseResult<boolean> {
+    if (this.error) {
+      return Promise.resolve(this.error)
+    }
+
+    return Promise.resolve(Boolean(this.items[key]))
+  }
+
   // @ts-ignore
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, class-methods-use-this
   upload<T>(fileName: string, content: T): PromiseResult<void> {

--- a/src/shared-testing/src/StepFunctionSimulator.ts
+++ b/src/shared-testing/src/StepFunctionSimulator.ts
@@ -3,11 +3,14 @@
 export default class StepFunctionSimulator {
   private steps: Function[]
 
+  private outputs: unknown[]
+
   constructor(steps: Function[]) {
     this.steps = steps
   }
 
   async execute(input: any, log = false): Promise<any> {
+    this.outputs = []
     let inputValue = input
 
     for (const step of this.steps) {
@@ -15,7 +18,12 @@ export default class StepFunctionSimulator {
         console.log(step, inputValue)
       }
       inputValue = await step(inputValue)
+      this.outputs.push(inputValue)
     }
     return inputValue
+  }
+
+  getOutput(functionIndex: number) {
+    return this.outputs[functionIndex]
   }
 }

--- a/src/shared-types/src/S3GatewayInterface.ts
+++ b/src/shared-types/src/S3GatewayInterface.ts
@@ -5,6 +5,7 @@ export default interface S3GatewayInterface {
   forBucket(bucketName: string): S3GatewayInterface
   getBucketName(): string
   getItem(key: string): PromiseResult<string>
+  doesItemExist(key: string): PromiseResult<boolean>
   upload<T>(fileName: string, content: T): PromiseResult<void>
   list(): PromiseResult<S3.ObjectList>
   copyItemTo(key: string, destinationBucketName: string): PromiseResult<void>

--- a/src/shared/src/S3/AwsS3Gateway.integration.test.ts
+++ b/src/shared/src/S3/AwsS3Gateway.integration.test.ts
@@ -67,6 +67,22 @@ describe("AwsS3Gateway", () => {
     })
   })
 
+  describe("doesItemExist()", () => {
+    it("should return true when object exists in the bucket", async () => {
+      await gateway.upload(fileName, "Message to be saved")
+
+      const result = await gateway.doesItemExist(fileName)
+
+      expect(result).toBe(true)
+    })
+
+    it("should return false when object does not exist in the bucket", async () => {
+      const result = await gateway.doesItemExist("non-existent-object-key")
+
+      expect(result).toBe(false)
+    })
+  })
+
   describe("upload()", () => {
     it("should save the message in the bucket", async () => {
       const result = await gateway.upload(fileName, "Message to be saved")

--- a/src/shared/src/S3/AwsS3Gateway.ts
+++ b/src/shared/src/S3/AwsS3Gateway.ts
@@ -54,6 +54,25 @@ export default class AwsS3Gateway implements S3GatewayInterface {
       .catch((error) => <Error>error)
   }
 
+  doesItemExist(key: string): PromiseResult<boolean> {
+    return this.s3
+      .headObject({
+        Bucket: this.getBucketName(),
+        Key: key
+      })
+      .promise()
+      .then(
+        () => true,
+        (error: AWS.AWSError) => {
+          if (error.code === "NotFound") {
+            return false
+          }
+          return error
+        }
+      )
+      .catch((error) => <Error>error)
+  }
+
   upload<T>(fileName: string, content: T): PromiseResult<void> {
     const params: S3.Types.PutObjectRequest = {
       Bucket: this.getBucketName(),


### PR DESCRIPTION
In this PR:
- Store Event lambda updated to check the existence of the S3 object before retrieving the content
- If the S3 object does not exist, state machine execution ends successfully
- Added `doesItemExist` function to `AwsS3Gateway`