### PR TITLE
Set expiry times on audit log and audit log lookup items in the E2E test environment

### DIFF
--- a/src/shared-types/src/AuditLog.ts
+++ b/src/shared-types/src/AuditLog.ts
@@ -41,6 +41,8 @@ export default class AuditLog {
 
   public readonly version = 0
 
+  public expiryTime?: string
+
   constructor(
     public readonly externalCorrelationId: string,
     receivedDate: Date,

--- a/src/shared-types/src/AuditLogLookup.ts
+++ b/src/shared-types/src/AuditLogLookup.ts
@@ -5,6 +5,8 @@ export default class AuditLogLookup {
 
   public isCompressed?: boolean
 
+  public expiryTime?: string
+
   constructor(public readonly value: string, public readonly messageId: string) {
     this.id = uuid()
   }

--- a/src/shared/package-lock.json
+++ b/src/shared/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "aws-sdk": "^2.1069.0",
         "axios": "^0.25.0",
+        "date-fns": "^2.28.0",
         "pg": "^8.7.3",
         "pg-native": "^3.0.0",
         "pino": "^6.13.0",
@@ -28,7 +29,6 @@
         "@types/xml2js": "^0.4.9",
         "@typescript-eslint/eslint-plugin": "^5.10.2",
         "@typescript-eslint/parser": "^5.10.2",
-        "date-fns": "^2.28.0",
         "eslint": "^8.8.0",
         "jest": "^27.5.0",
         "jest-junit": "^13.0.0",
@@ -10600,7 +10600,6 @@
     },
     "node_modules/date-fns": {
       "version": "2.28.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.11"
@@ -15128,8 +15127,7 @@
       }
     },
     "date-fns": {
-      "version": "2.28.0",
-      "dev": true
+      "version": "2.28.0"
     },
     "debug": {
       "version": "4.3.3",

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -17,7 +17,6 @@
     "@types/xml2js": "^0.4.9",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
-    "date-fns": "^2.28.0",
     "eslint": "^8.8.0",
     "jest": "^27.5.0",
     "jest-junit": "^13.0.0",
@@ -29,6 +28,7 @@
   "dependencies": {
     "aws-sdk": "^2.1069.0",
     "axios": "^0.25.0",
+    "date-fns": "^2.28.0",
     "pg": "^8.7.3",
     "pg-native": "^3.0.0",
     "pino": "^6.13.0",

--- a/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.integration.test.ts
+++ b/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.integration.test.ts
@@ -1,6 +1,6 @@
 jest.retryTimes(10)
 import type { DocumentClient } from "aws-sdk/clients/dynamodb"
-import { addDays, differenceInDays, subHours } from "date-fns"
+import { addDays } from "date-fns"
 import "shared-testing"
 import type { DynamoDbConfig, EventCategory } from "shared-types"
 import { AuditLog, AuditLogEvent, AuditLogStatus, EventType, isError } from "shared-types"
@@ -96,9 +96,12 @@ describe("AuditLogDynamoGateway", () => {
 
       const actualMessage = <AuditLog>result
       expect(actualMessage.messageId).toBe(expectedMessage.messageId)
+
       expect(actualMessage.expiryTime).toBeDefined()
+      const secondsToExpiry = parseInt(actualMessage.expiryTime || "0") - new Date().getTime() / 1000
       // The expiry time will be very slightly sooner than 1 week just after we have created it, so give 1 hour margin
-      expect(differenceInDays(new Date(actualMessage.expiryTime || ""), subHours(new Date(), 1))).toBe(7)
+      expect(secondsToExpiry).toBeGreaterThanOrEqual((6 * 24 + 23) * 60 * 60)
+      expect(secondsToExpiry).toBeLessThanOrEqual(7 * 24 * 60 * 60)
     })
   })
 

--- a/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
+++ b/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
@@ -25,10 +25,8 @@ export default class AwsAuditLogDynamoGateway extends DynamoGateway implements A
   }
 
   async create(message: AuditLog): PromiseResult<AuditLog> {
-    // set an expiry time if we are in the e2e environment
-    const expiryTime = addDays(new Date(), parseInt(process.env.EXPIRY_DAYS || "7"))
     if (process.env.IS_E2E) {
-      message.expiryTime = expiryTime.toISOString()
+      message.expiryTime = addDays(new Date(), parseInt(process.env.EXPIRY_DAYS || "7")).toISOString()
     }
 
     const result = await this.insertOne(this.tableName, message, "messageId")

--- a/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
+++ b/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
@@ -1,3 +1,4 @@
+import { addDays } from "date-fns"
 import type {
   AuditLog,
   AuditLogDynamoGateway,
@@ -24,6 +25,12 @@ export default class AwsAuditLogDynamoGateway extends DynamoGateway implements A
   }
 
   async create(message: AuditLog): PromiseResult<AuditLog> {
+    // set an expiry time if we are in the e2e environment
+    const expiryTime = addDays(new Date(), parseInt(process.env.EXPIRY_DAYS || "7"))
+    if (process.env.IS_E2E) {
+      message.expiryTime = expiryTime.toISOString()
+    }
+
     const result = await this.insertOne(this.tableName, message, "messageId")
 
     if (isError(result)) {

--- a/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
+++ b/src/shared/src/AuditLogDynamoGateway/AwsAuditLogDynamoGateway.ts
@@ -26,7 +26,9 @@ export default class AwsAuditLogDynamoGateway extends DynamoGateway implements A
 
   async create(message: AuditLog): PromiseResult<AuditLog> {
     if (process.env.IS_E2E) {
-      message.expiryTime = addDays(new Date(), parseInt(process.env.EXPIRY_DAYS || "7")).toISOString()
+      message.expiryTime = Math.round(
+        addDays(new Date(), parseInt(process.env.EXPIRY_DAYS || "7")).getTime() / 1000
+      ).toString()
     }
 
     const result = await this.insertOne(this.tableName, message, "messageId")

--- a/src/shared/src/AuditLogLookupDynamoGateway/AwsAuditLogLookupDynamoGateway.ts
+++ b/src/shared/src/AuditLogLookupDynamoGateway/AwsAuditLogLookupDynamoGateway.ts
@@ -21,7 +21,9 @@ export default class AwsAuditLogLookupDynamoGateway extends DynamoGateway implem
 
   async create(lookupItem: AuditLogLookup): PromiseResult<AuditLogLookup> {
     if (process.env.IS_E2E) {
-      lookupItem.expiryTime = addDays(new Date(), parseInt(process.env.EXPIRY_DAYS || "7")).toISOString()
+      lookupItem.expiryTime = Math.round(
+        addDays(new Date(), parseInt(process.env.EXPIRY_DAYS || "7")).getTime() / 1000
+      ).toString()
     }
 
     const itemToSave = { ...lookupItem, value: await compress(lookupItem.value), isCompressed: true }

--- a/src/shared/src/AuditLogLookupDynamoGateway/AwsAuditLogLookupDynamoGateway.ts
+++ b/src/shared/src/AuditLogLookupDynamoGateway/AwsAuditLogLookupDynamoGateway.ts
@@ -1,3 +1,4 @@
+import { addDays } from "date-fns"
 import type { AuditLogLookupDynamoGateway, AuditLogLookup, DynamoDbConfig, PromiseResult } from "shared-types"
 import { isError } from "shared-types"
 import { compress, decompress } from ".."
@@ -19,7 +20,12 @@ export default class AwsAuditLogLookupDynamoGateway extends DynamoGateway implem
   }
 
   async create(lookupItem: AuditLogLookup): PromiseResult<AuditLogLookup> {
+    if (process.env.IS_E2E) {
+      lookupItem.expiryTime = addDays(new Date(), parseInt(process.env.EXPIRY_DAYS || "7")).toISOString()
+    }
+
     const itemToSave = { ...lookupItem, value: await compress(lookupItem.value), isCompressed: true }
+
     const result = await this.insertOne(this.tableName, itemToSave, "id")
 
     if (isError(result)) {


### PR DESCRIPTION
The `expiryTime` needs to be set on newly created items to ensure they are deleted eventually, and the dynamodb TTL will be enabled for the E2E environment in terraform

The behaviour is controlled by the `IS_E2E` environment variable, which is also set in terraform

In all other environments the expiryTime column should not be populated