### PR TITLE
Add more event types to status calculation logic

### DIFF
--- a/src/shared-types/src/EventType.ts
+++ b/src/shared-types/src/EventType.ts
@@ -11,6 +11,7 @@ enum EventType {
   RecordIgnoredNoOffences = "Hearing Outcome ignored as it contains no offences",
   StatutoryDeclarationCaseIgnored = "Re-opened / Statutory Declaration case ignored",
   InterimHearingWithAncillaryOnlyCourtResults_PncNotUpdated = "Interim hearing with ancillary only court results. PNC not updated",
+  FailedToUpdatePnc = "Message Rejected by [PNCUpdateProcessorBean] MDB",
   Retrying = "Retrying failed message"
 }
 

--- a/src/shared-types/src/EventType.ts
+++ b/src/shared-types/src/EventType.ts
@@ -9,6 +9,8 @@ enum EventType {
   PncUpdated = "PNC Update applied successfully",
   RecordIgnoredNoRecordableOffences = "Hearing Outcome ignored as no offences are recordable",
   RecordIgnoredNoOffences = "Hearing Outcome ignored as it contains no offences",
+  StatutoryDeclarationCaseIgnored = "Re-opened / Statutory Declaration case ignored",
+  InterimHearingWithAncillaryOnlyCourtResults_PncNotUpdated = "Interim hearing with ancillary only court results. PNC not updated",
   Retrying = "Retrying failed message"
 }
 

--- a/src/shared/src/AuditLogDynamoGateway/CalculateMessageStatusUseCase.ts
+++ b/src/shared/src/AuditLogDynamoGateway/CalculateMessageStatusUseCase.ts
@@ -92,6 +92,8 @@ export default class CalculateMessageStatusUseCase {
 
   private get recordIsIgnored(): boolean {
     return (
+      this.hasEventType(EventType.InterimHearingWithAncillaryOnlyCourtResults_PncNotUpdated) ||
+      this.hasEventType(EventType.StatutoryDeclarationCaseIgnored) ||
       this.hasEventType(EventType.RecordIgnoredNoOffences) ||
       this.hasEventType(EventType.RecordIgnoredNoRecordableOffences)
     )


### PR DESCRIPTION
This PR adds 2 missing event types to `CalculateMessageStatusUseCase`:
- Re-opened / Statutory Declaration case ignored
- Interim hearing with ancillary only court results. PNC not updated