### PR TITLE
Fix error with identifying top exceptions events

### DIFF
--- a/src/audit-log-api/src/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.integration.test.ts
+++ b/src/audit-log-api/src/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.integration.test.ts
@@ -265,7 +265,7 @@ describe("AuditLogDynamoGateway", () => {
     it("should log the event for top exceptions report", async () => {
       const expectedEvent = createAuditLogEvent("information", new Date(), "Event for top exceptions report")
 
-      expectedEvent.addAttribute("Message Type", "SPIResults")
+      expectedEvent.addAttribute("eventCode", "exceptions.generated")
       expectedEvent.addAttribute("Error 2 Details", "Dummy")
 
       const message = new AuditLog("one", new Date(), "dummy hash")
@@ -302,7 +302,7 @@ describe("AuditLogDynamoGateway", () => {
 
       const actualEventAttributes = actualEvent.attributes
       expect(actualEventAttributes).toBeDefined()
-      expect(actualEventAttributes["Message Type"]).toBe("SPIResults")
+      expect(actualEventAttributes.eventCode).toBe("exceptions.generated")
       expect(actualEventAttributes["Error 2 Details"]).toBe("Dummy")
 
       const actualTopExceptionReportEvent = actualMessage.topExceptionsReport?.events[0]
@@ -313,7 +313,7 @@ describe("AuditLogDynamoGateway", () => {
 
       const actualTopExceptionReportEventAttribute = actualTopExceptionReportEvent?.attributes
       expect(actualTopExceptionReportEventAttribute).toBeDefined()
-      expect(actualTopExceptionReportEventAttribute?.["Message Type"]).toBe("SPIResults")
+      expect(actualTopExceptionReportEventAttribute?.eventCode).toBe("exceptions.generated")
       expect(actualTopExceptionReportEventAttribute?.["Error 2 Details"]).toBe("Dummy")
     })
 
@@ -1123,7 +1123,7 @@ describe("AuditLogDynamoGateway", () => {
         createAuditLogEvent("information", new Date(), "SPIResults")
       ]
       eventsToBeLogged.forEach((event) => {
-        event.addAttribute("Message Type", "SPIResults")
+        event.addAttribute("eventCode", "exceptions.generated")
         event.addAttribute("Error Details", "An error occured")
       })
       const eventsNotToBeLogged = [

--- a/src/audit-log-api/src/gateways/dynamo/AuditLogDynamoGateway/shouldLogForTopExceptionsReport.test.ts
+++ b/src/audit-log-api/src/gateways/dynamo/AuditLogDynamoGateway/shouldLogForTopExceptionsReport.test.ts
@@ -1,10 +1,10 @@
 import type { AuditLogEvent } from "shared-types"
 import shouldLogForTopExceptionsReport from "./shouldLogForTopExceptionsReport"
 
-it("should return true when event has correct message type and error details attribute", () => {
+it("should return true when event has correct event code attribute", () => {
   const event = {
     attributes: {
-      "Message Type": "SPIResults",
+      eventCode: "exceptions.generated",
       "Error 1 Details": "Dummy"
     }
   } as unknown as AuditLogEvent
@@ -14,46 +14,11 @@ it("should return true when event has correct message type and error details att
   expect(result).toBe(true)
 })
 
-it("should return true when event has correct message type but does not have error details attribute", () => {
+it("should return false when event has incorrect event code attribute", () => {
   const event = {
     attributes: {
-      "Message Type": "SPIResults"
+      eventCode: "dummy"
     }
-  } as unknown as AuditLogEvent
-
-  const result = shouldLogForTopExceptionsReport(event)
-
-  expect(result).toBe(false)
-})
-
-it("should return true when event has error details attribute but message type is incorrect", () => {
-  const event = {
-    attributes: {
-      "Message Type": "Incorrect Message Type",
-      "Error 1 Details": "Dummy"
-    }
-  } as unknown as AuditLogEvent
-
-  const result = shouldLogForTopExceptionsReport(event)
-
-  expect(result).toBe(false)
-})
-
-it("should return true when event has error details attribute but message type attribute does not exist", () => {
-  const event = {
-    attributes: {
-      "Error 1 Details": "Dummy"
-    }
-  } as unknown as AuditLogEvent
-
-  const result = shouldLogForTopExceptionsReport(event)
-
-  expect(result).toBe(false)
-})
-
-it("should return true when event has not error details attribute and message type attribute does not exist", () => {
-  const event = {
-    attributes: {}
   } as unknown as AuditLogEvent
 
   const result = shouldLogForTopExceptionsReport(event)

--- a/src/audit-log-api/src/gateways/dynamo/AuditLogDynamoGateway/shouldLogForTopExceptionsReport.ts
+++ b/src/audit-log-api/src/gateways/dynamo/AuditLogDynamoGateway/shouldLogForTopExceptionsReport.ts
@@ -1,11 +1,3 @@
 import type { AuditLogEvent } from "shared-types"
 
-export default (event: AuditLogEvent): boolean => {
-  const { attributes } = event
-  const hasCorrectMessageType = attributes["Message Type"] === "SPIResults"
-  const hasErrorDetailsAttribute = Object.keys(attributes).some((attributeName) =>
-    attributeName.match(/Error.*Details/)
-  )
-
-  return hasCorrectMessageType && hasErrorDetailsAttribute
-}
+export default (event: AuditLogEvent): boolean => event.attributes.eventCode === "exceptions.generated"

--- a/src/audit-log-api/src/gateways/dynamo/AuditLogDynamoGateway/updateComponents/topExceptionsReportUpdateComponent.test.ts
+++ b/src/audit-log-api/src/gateways/dynamo/AuditLogDynamoGateway/updateComponents/topExceptionsReportUpdateComponent.test.ts
@@ -5,7 +5,7 @@ const topExceptionEvent = (): AuditLogEvent => {
   return {
     eventType: "top exception event",
     attributes: {
-      "Message Type": "SPIResults",
+      eventCode: "exceptions.generated",
       "Error Details": "error"
     }
   } as unknown as AuditLogEvent

--- a/src/audit-log-api/src/use-cases/FetchTopExceptionsReport.ts
+++ b/src/audit-log-api/src/use-cases/FetchTopExceptionsReport.ts
@@ -17,8 +17,7 @@ export default class FetchTopExceptionsReport implements MessageFetcher {
 
     const records = await this.gateway.fetchRange({
       ...this.options,
-      includeColumns: ["topExceptionsReport", "automationReport"],
-      excludeColumns: ["events"],
+      includeColumns: ["automationReport"],
       lastMessage
     })
 
@@ -27,12 +26,7 @@ export default class FetchTopExceptionsReport implements MessageFetcher {
     }
 
     return records.map((record) => {
-      record.events = []
-
-      if (record.topExceptionsReport) {
-        record.events = record.topExceptionsReport.events
-        delete record.topExceptionsReport
-      }
+      record.events = record.events.filter((e) => e.attributes && "Error 1 Details" in e.attributes)
 
       if (record.automationReport) {
         if (!record.forceOwner && record.automationReport.forceOwner) {


### PR DESCRIPTION
One of the attributes used to identify top exceptions events was mistakenly removed in the audit logging re-org. This makes the topExceptions query use the main events attribute and filter it server side and re-works the event detection to use the new eventCode attribute