### PR TITLE
Refactor API statusCodeLookup to ensure all resultTypes are handled

### DIFF
--- a/src/audit-log-api/handlers/createAuditLogEvent.ts
+++ b/src/audit-log-api/handlers/createAuditLogEvent.ts
@@ -50,7 +50,7 @@ export default async function createAuditLogEvent(event: APIGatewayProxyEvent): 
 
   logger.error(result.resultDescription ?? `Unexpected error (${result.resultType})`)
   return createJsonApiResult({
-    statusCode: statusCodeLookup[result.resultType] ?? HttpStatusCode.internalServerError,
+    statusCode: statusCodeLookup[result.resultType] ?? (HttpStatusCode.internalServerError as never),
     body: result.resultDescription
   })
 }

--- a/src/audit-log-api/utils/statusCodeLookup.ts
+++ b/src/audit-log-api/utils/statusCodeLookup.ts
@@ -1,6 +1,6 @@
 import { HttpStatusCode } from "src/shared"
 
-const statusCodeLookup: { [k: string]: number } = {
+const statusCodeLookup = {
   success: HttpStatusCode.ok,
   notFound: HttpStatusCode.notFound,
   invalidVersion: HttpStatusCode.conflict,


### PR DESCRIPTION
This is a PR containing the change we discussed in a group mobbing session.

The use of `never` here ensures that the `statusCodeLookup` object contains all possible values for the `resultType` as keys. If it doesn't, the typescript compiler will complain about the key not existing on the type.