### PR TITLE
Add all triggers resolved to calculate message status use case

### DIFF
--- a/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/CalculateMessageStatusUseCase.test.ts
+++ b/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/CalculateMessageStatusUseCase.test.ts
@@ -26,54 +26,76 @@ const prePNCUpdateTriggersGeneratedEvent = () =>
   })
 const postPNCUpdateTriggersGeneratedEvent = () =>
   createEvent(EventCode.TriggersGenerated, "information", { "Trigger 1 Details": "TRPS0003" })
+const allTriggersResolvedEvent = () => createEvent(EventCode.AllTriggersResolved, "information")
 const triggerInstancesResolvedEvent = () =>
   createEvent(EventCode.TriggersResolved, "information", {
-    "Trigger Code 01": "TRPR0004",
-    "Trigger Code 02": "TRPR0004",
-    "Trigger Code 03": "TRPR0006",
-    "Trigger Code 04": "TRPS0003"
+    "Trigger 1 Details": "TRPR0004",
+    "Trigger 2 Details": "TRPR0004",
+    "Trigger 3 Details": "TRPR0006",
+    "Trigger 4 Details": "TRPS0003"
   })
 const triggerInstancesPartiallyResolvedEvent = () =>
   createEvent(EventCode.TriggersResolved, "information", {
-    "Trigger Code 01": "TRPR0004",
-    "Trigger Code 02": "TRPR0004"
+    "Trigger 1 Details": "TRPR0004",
+    "Trigger 2 Details": "TRPR0004"
   })
 const exceptionsManuallyResolvedEvent = () => createEvent(EventCode.ExceptionsResolved)
 
 describe("CalculateMessageStatusUseCase", () => {
   describe("overall message status", () => {
     it("should not affect the status calculation when message has sanitised event", () => {
-      const { status } = new CalculateMessageStatusUseCase(errorEvent(), sanitisedEvent(), archivedRecordEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
+        errorEvent(),
+        sanitisedEvent(),
+        archivedRecordEvent()
+      ).call()
 
       expect(status).toBe(AuditLogStatus.error)
+      expect(pncStatus).toBe(PncStatus.Processing)
+      expect(triggerStatus).toBe(TriggerStatus.NoTriggers)
     })
 
     it("should not affect the status calculation when message has error record archival event", () => {
-      const { status } = new CalculateMessageStatusUseCase(errorEvent(), archivedRecordEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
+        errorEvent(),
+        archivedRecordEvent()
+      ).call()
 
       expect(status).toBe(AuditLogStatus.error)
+      expect(pncStatus).toBe(PncStatus.Processing)
+      expect(triggerStatus).toBe(TriggerStatus.NoTriggers)
     })
 
     it("should return Completed status when there are no exceptions and triggers, and PNC is updated", () => {
-      const { status } = new CalculateMessageStatusUseCase(pncUpdatedEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(pncUpdatedEvent()).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Updated)
+      expect(triggerStatus).toBe(TriggerStatus.NoTriggers)
     })
 
     it("should return Completed status when there are no exceptions and triggers, and record is ignored (no offences)", () => {
-      const { status } = new CalculateMessageStatusUseCase(recordIgnoredNoOffencesEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
+        recordIgnoredNoOffencesEvent()
+      ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Ignored)
+      expect(triggerStatus).toBe(TriggerStatus.NoTriggers)
     })
 
     it("should return Completed status when there are no exceptions and triggers, and record is ignored (no recordable offences)", () => {
-      const { status } = new CalculateMessageStatusUseCase(recordIgnoredNoRecordableOffencesEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
+        recordIgnoredNoRecordableOffencesEvent()
+      ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Ignored)
+      expect(triggerStatus).toBe(TriggerStatus.NoTriggers)
     })
 
     it("should return Completed status when there are no exceptions, triggers are resolved, and PNC is updated", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         prePNCUpdateTriggersGeneratedEvent(),
         postPNCUpdateTriggersGeneratedEvent(),
         triggerInstancesResolvedEvent(),
@@ -81,10 +103,12 @@ describe("CalculateMessageStatusUseCase", () => {
       ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Updated)
+      expect(triggerStatus).toBe(TriggerStatus.Resolved)
     })
 
     it("should return Completed status when there are no exceptions, triggers are resolved, and record is ignored", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         prePNCUpdateTriggersGeneratedEvent(),
         postPNCUpdateTriggersGeneratedEvent(),
         triggerInstancesResolvedEvent(),
@@ -92,37 +116,62 @@ describe("CalculateMessageStatusUseCase", () => {
       ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Ignored)
+      expect(triggerStatus).toBe(TriggerStatus.Resolved)
     })
 
     it("should return Completed status when exceptions are resolved and resubmitted, there are no triggers, and record is ignored", () => {
-      const { status } = new CalculateMessageStatusUseCase(recordIgnoredNoRecordableOffencesEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
+        recordIgnoredNoRecordableOffencesEvent()
+      ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Ignored)
+      expect(triggerStatus).toBe(TriggerStatus.NoTriggers)
+    })
+
+    it("should return Completed status when there are no exceptions, all triggers resolved event exists, and PNC is updated", () => {
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
+        prePNCUpdateTriggersGeneratedEvent(),
+        postPNCUpdateTriggersGeneratedEvent(),
+        allTriggersResolvedEvent(),
+        pncUpdatedEvent()
+      ).call()
+
+      expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Updated)
+      expect(triggerStatus).toBe(TriggerStatus.Resolved)
     })
 
     it("should return Completed status when exceptions are resolved and resubmitted, there are no triggers, and PNC is updated", () => {
-      const { status } = new CalculateMessageStatusUseCase(pncUpdatedEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(pncUpdatedEvent()).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Updated)
+      expect(triggerStatus).toBe(TriggerStatus.NoTriggers)
     })
 
     it("should return Completed status when exceptions are manually resolved, there are no triggers, and record is ignored", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         exceptionsManuallyResolvedEvent(),
         recordIgnoredNoRecordableOffencesEvent()
       ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Ignored)
+      expect(triggerStatus).toBe(TriggerStatus.NoTriggers)
     })
 
     it("should return Completed status when exceptions are manually resolved, there are no triggers, and PNC is updated", () => {
-      const { status } = new CalculateMessageStatusUseCase(exceptionsManuallyResolvedEvent(), pncUpdatedEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(exceptionsManuallyResolvedEvent(), pncUpdatedEvent()).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Updated)
+      expect(triggerStatus).toBe(TriggerStatus.NoTriggers)
     })
 
     it("should return Completed status when exceptions are resolved and resubmitted, triggers are resolved, and record is ignored", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         prePNCUpdateTriggersGeneratedEvent(),
         postPNCUpdateTriggersGeneratedEvent(),
         triggerInstancesResolvedEvent(),
@@ -130,10 +179,12 @@ describe("CalculateMessageStatusUseCase", () => {
       ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Ignored)
+      expect(triggerStatus).toBe(TriggerStatus.Resolved)
     })
 
     it("should return Completed status when exceptions are resolved and resubmitted, triggers are resolved, and PNC is updated", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         prePNCUpdateTriggersGeneratedEvent(),
         postPNCUpdateTriggersGeneratedEvent(),
         triggerInstancesResolvedEvent(),
@@ -141,10 +192,12 @@ describe("CalculateMessageStatusUseCase", () => {
       ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Updated)
+      expect(triggerStatus).toBe(TriggerStatus.Resolved)
     })
 
     it("should return Completed status when exceptions are manually resolved, triggers are resolved, and record is ignored", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         exceptionsManuallyResolvedEvent(),
         prePNCUpdateTriggersGeneratedEvent(),
         postPNCUpdateTriggersGeneratedEvent(),
@@ -153,10 +206,12 @@ describe("CalculateMessageStatusUseCase", () => {
       ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Ignored)
+      expect(triggerStatus).toBe(TriggerStatus.Resolved)
     })
 
     it("should return Completed status when exceptions are manually resolved, triggers are resolved, and PNC is updated", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         exceptionsManuallyResolvedEvent(),
         prePNCUpdateTriggersGeneratedEvent(),
         postPNCUpdateTriggersGeneratedEvent(),
@@ -165,10 +220,12 @@ describe("CalculateMessageStatusUseCase", () => {
       ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
+      expect(pncStatus).toBe(PncStatus.Updated)
+      expect(triggerStatus).toBe(TriggerStatus.Resolved)
     })
 
     it("should return Retrying status when last event type is retrying", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         prePNCUpdateTriggersGeneratedEvent(),
         errorEvent(),
         retryingEvent(),
@@ -177,10 +234,12 @@ describe("CalculateMessageStatusUseCase", () => {
       ).call()
 
       expect(status).toBe(AuditLogStatus.retrying)
+      expect(pncStatus).toBe(PncStatus.Processing)
+      expect(triggerStatus).toBe(TriggerStatus.Generated)
     })
 
     it("should return Error status when there is an event with category Error", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         prePNCUpdateTriggersGeneratedEvent(),
         errorEvent(),
         retryingEvent(),
@@ -188,16 +247,20 @@ describe("CalculateMessageStatusUseCase", () => {
       ).call()
 
       expect(status).toBe(AuditLogStatus.error)
+      expect(pncStatus).toBe(PncStatus.Processing)
+      expect(triggerStatus).toBe(TriggerStatus.Generated)
     })
 
     it("should return Processing status when triggers are not resolved", () => {
-      const { status } = new CalculateMessageStatusUseCase(prePNCUpdateTriggersGeneratedEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(prePNCUpdateTriggersGeneratedEvent()).call()
 
       expect(status).toBe(AuditLogStatus.processing)
+      expect(pncStatus).toBe(PncStatus.Processing)
+      expect(triggerStatus).toBe(TriggerStatus.Generated)
     })
 
     it("should return Processing status when triggers are partially resolved", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         prePNCUpdateTriggersGeneratedEvent(),
         postPNCUpdateTriggersGeneratedEvent(),
         triggerInstancesPartiallyResolvedEvent(),
@@ -205,25 +268,31 @@ describe("CalculateMessageStatusUseCase", () => {
       ).call()
 
       expect(status).toBe(AuditLogStatus.processing)
+      expect(pncStatus).toBe(PncStatus.Ignored)
+      expect(triggerStatus).toBe(TriggerStatus.Generated)
     })
 
     it("should return Processing status when exceptions are not resolved", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         prePNCUpdateTriggersGeneratedEvent(),
         triggerInstancesResolvedEvent(),
         recordIgnoredNoRecordableOffencesEvent()
       ).call()
 
       expect(status).toBe(AuditLogStatus.processing)
+      expect(pncStatus).toBe(PncStatus.Ignored)
+      expect(triggerStatus).toBe(TriggerStatus.Generated)
     })
 
     it("should return Processing status when there are no PNC updated or record ignored events", () => {
-      const { status } = new CalculateMessageStatusUseCase(
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
         prePNCUpdateTriggersGeneratedEvent(),
         triggerInstancesResolvedEvent()
       ).call()
 
       expect(status).toBe(AuditLogStatus.processing)
+      expect(pncStatus).toBe(PncStatus.Processing)
+      expect(triggerStatus).toBe(TriggerStatus.Generated)
     })
   })
 

--- a/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/CalculateMessageStatusUseCase.test.ts
+++ b/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/CalculateMessageStatusUseCase.test.ts
@@ -29,15 +29,15 @@ const postPNCUpdateTriggersGeneratedEvent = () =>
 const allTriggersResolvedEvent = () => createEvent(EventCode.AllTriggersResolved, "information")
 const triggerInstancesResolvedEvent = () =>
   createEvent(EventCode.TriggersResolved, "information", {
-    "Trigger 1 Details": "TRPR0004",
-    "Trigger 2 Details": "TRPR0004",
+    "Trigger 1 Details": "TRPR0004 (1)",
+    "Trigger 2 Details": "TRPR0004 (2)",
     "Trigger 3 Details": "TRPR0006",
     "Trigger 4 Details": "TRPS0003"
   })
 const triggerInstancesPartiallyResolvedEvent = () =>
   createEvent(EventCode.TriggersResolved, "information", {
-    "Trigger 1 Details": "TRPR0004",
-    "Trigger 2 Details": "TRPR0004"
+    "Trigger 1 Details": "TRPR0004 (1)",
+    "Trigger 2 Details": "TRPR0004 (2)"
   })
 const exceptionsManuallyResolvedEvent = () => createEvent(EventCode.ExceptionsResolved)
 
@@ -163,7 +163,10 @@ describe("CalculateMessageStatusUseCase", () => {
     })
 
     it("should return Completed status when exceptions are manually resolved, there are no triggers, and PNC is updated", () => {
-      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(exceptionsManuallyResolvedEvent(), pncUpdatedEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
+        exceptionsManuallyResolvedEvent(),
+        pncUpdatedEvent()
+      ).call()
 
       expect(status).toBe(AuditLogStatus.completed)
       expect(pncStatus).toBe(PncStatus.Updated)
@@ -252,7 +255,9 @@ describe("CalculateMessageStatusUseCase", () => {
     })
 
     it("should return Processing status when triggers are not resolved", () => {
-      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(prePNCUpdateTriggersGeneratedEvent()).call()
+      const { status, pncStatus, triggerStatus } = new CalculateMessageStatusUseCase(
+        prePNCUpdateTriggersGeneratedEvent()
+      ).call()
 
       expect(status).toBe(AuditLogStatus.processing)
       expect(pncStatus).toBe(PncStatus.Processing)

--- a/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/CalculateMessageStatusUseCase.ts
+++ b/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/CalculateMessageStatusUseCase.ts
@@ -70,6 +70,10 @@ export default class CalculateMessageStatusUseCase {
   }
 
   private get triggersAreResolved(): boolean {
+    if (this.events.some((event) => event.eventCode === EventCode.AllTriggersResolved)) {
+      return true
+    }
+
     const triggersGeneratedEvents = this.events.filter((event) => event.eventCode === EventCode.TriggersGenerated)
     if (triggersGeneratedEvents.length === 0) {
       return false
@@ -82,14 +86,15 @@ export default class CalculateMessageStatusUseCase {
 
     const generatedTriggers = triggersGeneratedEvents.flatMap((event) =>
       Object.keys(event.attributes ?? {})
-        .filter((key) => /Trigger.*Details/i.test(key))
-        .map((key) => event.attributes[key])
+        .filter((key) => /Trigger \d+ Details/i.test(key))
+        .map((key) => String(event.attributes[key]))
     )
 
     const resolvedTriggers = triggerResolvedEvents.flatMap((event) =>
       Object.keys(event.attributes ?? {})
-        .filter((key) => /Trigger Code.*/i.test(key))
-        .map((key) => event.attributes[key])
+        .filter((key) => /Trigger \d+ Details.*/i.test(key))
+        .map((key) => String(event.attributes[key]).match(/(TRP[RS]\d{4})/)?.[1])
+        .filter((value) => value)
     )
 
     return (

--- a/src/audit-log-api/handlers/createAuditLogEvent.e2e.test.ts
+++ b/src/audit-log-api/handlers/createAuditLogEvent.e2e.test.ts
@@ -123,7 +123,7 @@ describe("Creating Audit Log event", () => {
       expect(triggerStatus).toBe("Generated")
 
       event = mockAuditLogEvent({ eventCode: EventCode.TriggersResolved })
-      event.addAttribute("Trigger Code", "TRPR0001")
+      event.addAttribute("Trigger 1 Details", "TRPR0001")
       await axios.post(`http://localhost:3010/messages/${auditLog.messageId}/events`, event)
 
       triggerStatus = await getTriggerStatus(auditLog.messageId)

--- a/src/audit-log-api/use-cases/CreateAuditLogEventUseCase.integration.test.ts
+++ b/src/audit-log-api/use-cases/CreateAuditLogEventUseCase.integration.test.ts
@@ -61,6 +61,9 @@ describe("CreateAuditLogEventUseCase", () => {
   beforeEach(async () => {
     await testAuditLogDynamoGateway.deleteAll(auditLogDynamoConfig.TABLE_NAME, "messageId")
     await testAuditLogLookupDynamoGateway.deleteAll(auditLogLookupDynamoConfig.TABLE_NAME, "id")
+  })
+
+  afterEach(() => {
     jest.clearAllMocks()
   })
 
@@ -208,7 +211,7 @@ describe("CreateAuditLogEventUseCase", () => {
     const event = createAuditLogEvent()
     event.addAttribute("reallyLongAttribute", "X".repeat(10_000))
 
-    jest
+    const spy = jest
       .spyOn(auditLogDynamoGateway, "executeTransaction")
       .mockResolvedValueOnce(new Error("Failed to create audit log table entry"))
 
@@ -222,6 +225,7 @@ describe("CreateAuditLogEventUseCase", () => {
 
     const lookupResult = await lookupMessageId(auditLog.messageId)
     expect(lookupResult).toBeNull()
+    spy.mockRestore()
   })
 
   it("should try 10 times to add the event if there is a version conflict", async () => {
@@ -254,6 +258,7 @@ describe("CreateAuditLogEventUseCase", () => {
     const actualAuditLog = await getAuditLog(auditLog.messageId)
     expect(actualAuditLog).toBeDefined()
     expect(actualAuditLog?.events).toHaveLength(1)
+    spy.mockRestore()
   })
 
   it("should try 10 times to add the event if there is a transaction conflict", async () => {
@@ -284,6 +289,7 @@ describe("CreateAuditLogEventUseCase", () => {
     const actualAuditLog = await getAuditLog(auditLog.messageId)
     expect(actualAuditLog).toBeDefined()
     expect(actualAuditLog?.events).toHaveLength(1)
+    spy.mockRestore()
   })
 
   it("should still return an error if there is a conflict after 10 attempts", async () => {
@@ -310,5 +316,6 @@ describe("CreateAuditLogEventUseCase", () => {
 
     const lookupResult = await lookupMessageId(auditLog.messageId)
     expect(lookupResult).toBeNull()
+    spy.mockRestore()
   })
 })

--- a/src/shared/types/EventCode.ts
+++ b/src/shared/types/EventCode.ts
@@ -1,6 +1,7 @@
 enum EventCode {
   TriggersGenerated = "triggers.generated",
   TriggersResolved = "triggers.resolved",
+  AllTriggersResolved = "triggers.all-resolved",
   ExceptionsResolved = "exceptions.resolved",
   PncUpdated = "pnc.updated",
   IgnoredNonrecordable = "hearing-outcome.ignored.nonrecordable",


### PR DESCRIPTION
This PR adds `AllTriggersResolved` to EventCode and updates the `CalculateMessageStatusUseCase` to return resolved trigger status when this event exists in an audit log record.

This PR also fixes `CreateAuditLogEventUseCase.integration.test` flakiness when clearing mocks.