### PR TITLE
Fix auto-update script now that `make install` has gone

### DIFF
--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 16.13.1
 
       - name: Install dependencies
-        run: make install
+        run: npm install
 
       - name: Update dependencies
         run: npm run update-deps

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:unit:watch": "jest --watchAll --testPathIgnorePatterns='integration' 'e2e' 'src/audit-log-portal/*'",
     "test:unit": "jest --testPathIgnorePatterns='integration' 'e2e' 'src/audit-log-portal/*'",
     "test": "jest --runInBand  --testPathIgnorePatterns='src/audit-log-portal/*' --namePattern=",
-    "update-deps": "ncu -u --deep -x react -x react-dom -x @material-ui/core -x @testing-library/react && make install",
+    "update-deps": "ncu -u && npm install",
     "wait-for-api": "wait-on tcp:3010"
   },
   "lint-staged": {


### PR DESCRIPTION
This also excludes the portal from the auto-updates; we're going to kill it soon anyway.