### PR TITLE
Compress event xml too!

### DIFF
--- a/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.ts
+++ b/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.ts
@@ -1,8 +1,7 @@
 import { addDays } from "date-fns"
 import { compress, decompress } from "src/shared"
-import type { DynamoAuditLog, KeyValuePair, PromiseResult, ValueLookup } from "src/shared/types"
-import { AuditLogEvent, AuditLogLookup, isError } from "src/shared/types"
-import type { AuditLogEventAttributes } from "src/shared/types/AuditLogEvent"
+import type { DynamoAuditLog, KeyValuePair, PromiseResult } from "src/shared/types"
+import { AuditLogEvent, isError } from "src/shared/types"
 import type {
   EventsFilterOptions,
   FetchByStatusOptions,
@@ -144,19 +143,19 @@ export default class AuditLogDynamoGateway extends DynamoGateway implements Audi
         indexSearcher.useIndex("messageIdIndex").setIndexKeys("_messageId", auditLog.messageId, "timestamp")
       }
 
-      const events = await indexSearcher.execute()
+      const events = (await indexSearcher.execute()) ?? []
 
       if (isError(events)) {
         return events
       }
 
-      for (const event of events ?? []) {
-        const attributes = await this.decompressEventAttributes(event.attributes)
-        if (isError(attributes)) {
-          return attributes
+      for (let i = 0; i < events.length; i++) {
+        const decompressedEvent = await this.decompressEventValues(events[i])
+        if (isError(decompressedEvent)) {
+          return decompressedEvent
         }
 
-        event.attributes = attributes
+        events[i] = decompressedEvent
       }
 
       auditLog.events = (auditLog.events ?? [])
@@ -435,12 +434,12 @@ export default class AuditLogDynamoGateway extends DynamoGateway implements Audi
   private async prepareStoreEvents(messageId: string, events: AuditLogEvent[]): PromiseResult<DynamoUpdate[]> {
     const dynamoUpdates: DynamoUpdate[] = []
     for (const event of events) {
-      const attributes = await this.compressEventAttributes(event.attributes)
-      if (isError(attributes)) {
-        return attributes
+      const compressedEvent = await this.compressEventValues(event)
+      if (isError(compressedEvent)) {
+        return compressedEvent
       }
 
-      const eventToInsert = new AuditLogEvent({ ...event, _messageId: messageId, attributes })
+      const eventToInsert = new AuditLogEvent({ ...compressedEvent, _messageId: messageId })
       dynamoUpdates.push({
         Put: {
           Item: { ...eventToInsert, _: "_" },
@@ -454,31 +453,33 @@ export default class AuditLogDynamoGateway extends DynamoGateway implements Audi
     return dynamoUpdates
   }
 
-  private async compressEventAttributes(attributes: AuditLogEventAttributes): PromiseResult<AuditLogEventAttributes> {
-    const result: AuditLogEventAttributes = {}
-
-    const attributeKeys = Object.keys(attributes)
-
-    for (const attributeKey of attributeKeys) {
-      const attributeValue = attributes[attributeKey]
+  private async compressEventValues(event: AuditLogEvent): PromiseResult<AuditLogEvent> {
+    for (const attributeKey of Object.keys(event.attributes)) {
+      const attributeValue = event.attributes[attributeKey]
       if (attributeValue && typeof attributeValue === "string" && attributeValue.length > maxAttributeValueLength) {
         const compressedValue = await compress(attributeValue)
         if (isError(compressedValue)) {
           return compressedValue
         }
 
-        result[attributeKey] = { _compressedValue: compressedValue }
-      } else {
-        result[attributeKey] = attributeValue
+        event.attributes[attributeKey] = { _compressedValue: compressedValue }
       }
     }
-    return result
+
+    if (event.eventXml && typeof event.eventXml === "string" && event.eventXml.length > maxAttributeValueLength) {
+      const compressedValue = await compress(event.eventXml)
+      if (isError(compressedValue)) {
+        return compressedValue
+      }
+
+      event.eventXml = { _compressedValue: compressedValue }
+    }
+
+    return event
   }
 
-  private async decompressEventAttributes(attributes: AuditLogEventAttributes): PromiseResult<AuditLogEventAttributes> {
-    const result: AuditLogEventAttributes = {}
-
-    for (const [attributeKey, attributeValue] of Object.entries(attributes)) {
+  private async decompressEventValues(event: AuditLogEvent): PromiseResult<AuditLogEvent> {
+    for (const [attributeKey, attributeValue] of Object.entries(event.attributes)) {
       if (attributeValue && typeof attributeValue === "object" && "_compressedValue" in attributeValue) {
         const compressedValue = (attributeValue as { _compressedValue: string })._compressedValue
         const decompressedValue = await decompress(compressedValue)
@@ -486,12 +487,19 @@ export default class AuditLogDynamoGateway extends DynamoGateway implements Audi
           return decompressedValue
         }
 
-        result[attributeKey] = decompressedValue
-      } else {
-        result[attributeKey] = attributeValue
+        event.attributes[attributeKey] = decompressedValue
       }
     }
 
-    return result
+    if (event.eventXml && typeof event.eventXml === "object" && "_compressedValue" in event.eventXml) {
+      const decompressedValue = await decompress(event.eventXml._compressedValue)
+      if (isError(decompressedValue)) {
+        return decompressedValue
+      }
+
+      event.eventXml = decompressedValue
+    }
+
+    return event
   }
 }

--- a/src/shared/types/AuditLogEvent.ts
+++ b/src/shared/types/AuditLogEvent.ts
@@ -4,7 +4,7 @@ import type EventCategory from "./EventCategory"
 
 export type AuditLogEventAttributeLookupValue = { valueLookup: string }
 
-export type AuditLogEventAttributeCompressedValue = { _compressedValue: string }
+export type AuditLogEventCompressedValue = { _compressedValue: string }
 
 export type AuditLogEventDecompressedAttributeValue = string | number | boolean
 
@@ -18,7 +18,7 @@ export type AuditLogEventDecompressedAttributes = {
 
 export type AuditLogEventAttributeValue =
   | AuditLogEventDecompressedAttributeValue
-  | AuditLogEventAttributeCompressedValue
+  | AuditLogEventCompressedValue
   | AuditLogEventAttributeLookupValue
 
 // TODO: Split this into a type an an implementation
@@ -33,7 +33,7 @@ export default class AuditLogEvent {
 
   public readonly eventType: string
 
-  public readonly eventXml?: string
+  public eventXml?: string | AuditLogEventCompressedValue
 
   public readonly _id?: string
 

--- a/src/shared/types/AuditLogEventOptions.ts
+++ b/src/shared/types/AuditLogEventOptions.ts
@@ -1,4 +1,4 @@
-import type { AuditLogEventAttributes } from "./AuditLogEvent"
+import type { AuditLogEventAttributes, AuditLogEventCompressedValue } from "./AuditLogEvent"
 import type EventCategory from "./EventCategory"
 
 export default interface AuditLogEventOptions {
@@ -12,7 +12,7 @@ export default interface AuditLogEventOptions {
   eventSource: string
   eventSourceQueueName?: string
   eventType: string
-  eventXml?: string
+  eventXml?: string | AuditLogEventCompressedValue
   timestamp: Date | string
   user?: string
 }


### PR DESCRIPTION
This PR compresses long `eventXml` values in place in the new events dynamo table, and decompresses such values when fetching them back out of Dynamo.

It also removes a couple of `prepareLookupItems` functions which are no longer used.