### PR TITLE
Remove the code which was trying to create an audit log before every event

### DIFF
--- a/src/event-handler/use-cases/CreateEventUseCase.test.ts
+++ b/src/event-handler/use-cases/CreateEventUseCase.test.ts
@@ -22,14 +22,6 @@ describe("CreateEventUseCase", () => {
     expect(result).toBeUndefined()
   })
 
-  it("should fail when audit log API fails to create message", async () => {
-    const expectedError = new Error("Create audit log failed")
-    fakeApiClient.setErrorReturnedByFunctions(expectedError, ["createAuditLog"])
-    const result = await useCase.execute("DummyMessageId", {} as AuditLogEvent)
-
-    expect(result).toBeError(expectedError.message)
-  })
-
   it("should fail when audit log API fails to create event", async () => {
     const expectedError = new Error("Create event failed")
     fakeApiClient.setErrorReturnedByFunctions(expectedError, ["createEvent"])

--- a/src/event-handler/use-cases/CreateEventUseCase.ts
+++ b/src/event-handler/use-cases/CreateEventUseCase.ts
@@ -1,36 +1,13 @@
 import { logger } from "src/shared"
-import type { ApiClient, AuditLogEvent, InputApiAuditLog, PromiseResult } from "src/shared/types"
-import { isError } from "src/shared/types"
+import type { ApiClient, AuditLogEvent, PromiseResult } from "src/shared/types"
 
 export default class {
   constructor(private readonly api: ApiClient) {}
 
-  async execute(messageId: string, event: AuditLogEvent): PromiseResult<void> {
+  execute(messageId: string, event: AuditLogEvent): PromiseResult<void> {
     if (!messageId) {
       logger.info(`No messageId: ${JSON.stringify(event)}`)
-      return undefined
-    }
-
-    // Create a message if message ID doesn't exist in the database
-    // If message ID already exists, the API returns 409 error
-    const message: InputApiAuditLog = {
-      caseId: "Unknown",
-      createdBy: "Event handler",
-      externalCorrelationId: messageId,
-      externalId: messageId,
-      isSanitised: 0,
-      messageHash: messageId,
-      messageId,
-      receivedDate: "1970-01-01T00:00:00.000Z"
-    }
-    const createAuditLogResult = await this.api.createAuditLog(message)
-
-    if (
-      isError(createAuditLogResult) &&
-      /A message with Id .+ already exists/i.test(createAuditLogResult.message) === false &&
-      /Message hash already exists/i.test(createAuditLogResult.message) === false
-    ) {
-      return createAuditLogResult
+      return Promise.resolve(undefined)
     }
 
     return this.api.createEvent(messageId, event)


### PR DESCRIPTION
This is unnecessary, since all records in the database already have an audit log record - I exported all IDs from before 2022 and ran a script to check they were all in Dynamo already. They were.