### PR TITLE
Scripts to run Audit Log API in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,11 @@ validate:
 
 .PHONY: run-mq
 run-mq:
-	docker-compose -f environment/docker-compose.yml up -d mq
+	@( \
+		if [ "${SKIP_MQ}" != "true" ]; then \
+			docker-compose -f environment/docker-compose.yml up -d mq; \
+		fi; \
+  )
 
 .PHONY: stop-mq
 stop-mq:
@@ -19,7 +23,11 @@ stop-mq:
 
 .PHONY: run-pg
 run-pg:
-	docker-compose -f environment/docker-compose.yml up -d pg
+	@( \
+		if [ "${SKIP_PG}" != "true" ]; then \
+			docker-compose -f environment/docker-compose.yml up -d pg; \
+		fi; \
+  )
 
 .PHONY: stop-pg
 stop-pg:

--- a/scripts/wait-for-api.sh
+++ b/scripts/wait-for-api.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+command='wget --no-check-certificate -q http://localhost:3010/messages -O /dev/null';
+server_started_status_code=0;
+status=-1;
+to_wait=${1:-90};
+echo "Waiting for ${to_wait} seconds"
+
+until [[ $status == $server_started_status_code || $to_wait -le 0 ]]
+do
+  sleep 1;
+  printf "*"
+  eval $command;
+  status=$?
+  to_wait=$((to_wait-1))
+done
+
+if (( $status != $server_started_status_code )); then
+  printf "Audit Log API has not started"
+  exit 1;
+fi


### PR DESCRIPTION
This PR updates the makefile to allow skipping MQ and PG when running the Audit Log API. We will then use this in user service CI to only run Audit Log API (Serverless + DynamoDB).

e.g.

```
SKIP_PG=true SKIP_MQ=true npm run start-api
```

Also added a bash script to wait for the API to become available. We also use this script in the CI to ensure that Audit Log API is healthy.