### PR TITLE
Don't update esbuild automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "test:unit:watch": "jest --watchAll --testPathIgnorePatterns='integration' 'e2e'",
     "test:unit": "jest --testPathIgnorePatterns='integration' 'e2e'",
     "test": "jest --runInBand  --namePattern=",
-    "update-deps": "ncu -u && npm install",
+    "update-deps": "ncu -x esbuild -u && npm install",
     "wait-for-api": "wait-on tcp:3010"
   },
   "lint-staged": {


### PR DESCRIPTION
esbuild 17 is currently incompatible with serverless-esbuild, and updating esbuild to 17 causes `npm install` to fail: https://github.com/ministryofjustice/bichard7-next-audit-logging/actions/runs/4041764831/jobs/6948675353