### PR TITLE
Audit log api performance

### DIFF
--- a/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.integration.test.ts
+++ b/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.integration.test.ts
@@ -1043,7 +1043,7 @@ describe("AuditLogDynamoGateway", () => {
         attributes: {
           "Attribute 1": { _compressedValue: (await compress("Attribute 1 data".repeat(500))) as string }
         }
-      } as any)
+      })
 
       await testGateway.insertOne(auditLogDynamoConfig.eventsTableName, externalEvent, gateway.eventsTableKey)
 

--- a/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.integration.test.ts
+++ b/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.integration.test.ts
@@ -15,7 +15,7 @@ import type { ApiAuditLogEvent, DynamoAuditLog, DynamoAuditLogEvent, KeyValuePai
 import { AuditLogStatus, isError } from "src/shared/types"
 import { v4 as uuid } from "uuid"
 import TestDynamoGateway from "../../../test/TestDynamoGateway"
-import AuditLogDynamoGateway from "./AuditLogDynamoGateway"
+import AuditLogDynamoGateway, { getEventsPageLimit } from "./AuditLogDynamoGateway"
 import { randomInt } from "crypto"
 import { IndexSearcher } from "../DynamoGateway"
 
@@ -192,6 +192,26 @@ describe("AuditLogDynamoGateway", () => {
 
       const items = result as DynamoAuditLogEvent[]
       expect(items).toHaveLength(250)
+      expect(items.map((item) => item.timestamp)).toStrictEqual(expectedEvents.map((event) => event.timestamp))
+    })
+
+    it(`should return all events when a message has ${getEventsPageLimit} events as the page limit in the query`, async () => {
+      let expectedEvents: DynamoAuditLogEvent[] = []
+
+      const events = generateAuditLogEvents(getEventsPageLimit)
+      expectedEvents = expectedEvents.concat(events)
+      await gateway.createManyUserEvents(events)
+
+      expectedEvents = expectedEvents.sort((a, b) =>
+        a.timestamp > b.timestamp ? 1 : b.timestamp > a.timestamp ? -1 : 0
+      )
+
+      const result = await gateway.getEvents("dummy-id")
+
+      expect(isError(result)).toBe(false)
+
+      const items = result as DynamoAuditLogEvent[]
+      expect(items).toHaveLength(getEventsPageLimit)
       expect(items.map((item) => item.timestamp)).toStrictEqual(expectedEvents.map((event) => event.timestamp))
     })
 

--- a/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.ts
+++ b/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.ts
@@ -357,8 +357,8 @@ export default class AuditLogDynamoGateway extends DynamoGateway implements Audi
   }
 
   replaceAuditLog(auditLog: DynamoAuditLog, version: number): PromiseResult<void> {
-    const replacement = { ...auditLog, version: version + 1 }
-    delete (replacement as any).events
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { events, ...replacement } = { ...auditLog, version: version + 1 }
     return this.replaceOne(this.config.auditLogTableName, replacement, this.auditLogTableKey, version)
   }
 

--- a/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.ts
+++ b/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGateway.ts
@@ -28,6 +28,8 @@ import type DynamoUpdate from "../DynamoGateway/DynamoUpdate"
 import type AuditLogDynamoGatewayInterface from "./AuditLogDynamoGatewayInterface"
 
 const maxAttributeValueLength = 1000
+const getEventsPageLimit = 100
+const eventsFetcherParallelism = 20
 
 type InternalDynamoAuditLog = Omit<DynamoAuditLog, "events">
 type InternalDynamoAuditLogEvent = DynamoAuditLogEvent & { _id: string }
@@ -39,8 +41,6 @@ const convertDynamoAuditLogToInternal = (
   delete input.events
   return input
 }
-
-const getEventsPageLimit = 100
 
 export default class AuditLogDynamoGateway extends DynamoGateway implements AuditLogDynamoGatewayInterface {
   readonly auditLogTableKey: string = "messageId"
@@ -170,7 +170,7 @@ export default class AuditLogDynamoGateway extends DynamoGateway implements Audi
     auditLogs: DynamoAuditLog[],
     options: EventsFilterOptions = {}
   ): PromiseResult<void> {
-    const numberOfFetchers = Math.min(auditLogs.length, 20)
+    const numberOfFetchers = Math.min(auditLogs.length, eventsFetcherParallelism)
     const indexes = [...Array(auditLogs.length).keys()]
 
     const eventsFetcher = async () => {

--- a/src/shared/testing/mockAuditLogs.ts
+++ b/src/shared/testing/mockAuditLogs.ts
@@ -59,7 +59,9 @@ export const mockApiAuditLogEvent = (overrides: Partial<ApiAuditLogEvent> = {}):
   ...overrides
 })
 
-export const mockDynamoAuditLogEvent = (overrides: Partial<DynamoAuditLogEvent> = {}): DynamoAuditLogEvent => ({
+export const mockDynamoAuditLogEvent = (
+  overrides: Partial<DynamoAuditLogEvent & { _id?: string }> = {}
+): DynamoAuditLogEvent => ({
   ...mockApiAuditLogEvent(overrides),
   _automationReport: 0,
   _topExceptionsReport: 0,


### PR DESCRIPTION
This PR updates audit log dynamo gateway to:

- Fetch events for messages in parallel
- Stop fetching message's events if the events result is less than the page limit (it saves one Dynamodb query for each message)

Also fixed a couple of lint warnings.