### PR TITLE
Add fetch by hash to get messages endpoint

### DIFF
--- a/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGatewayInterface.ts
+++ b/src/audit-log-api/gateways/dynamo/AuditLogDynamoGateway/AuditLogDynamoGatewayInterface.ts
@@ -16,7 +16,7 @@ export default interface AuditLogDynamoGateway {
     externalCorrelationId: string,
     options?: ProjectionOptions
   ): PromiseResult<DynamoAuditLog | null>
-  fetchByHash(hash: string): PromiseResult<DynamoAuditLog | null>
+  fetchByHash(hash: string, options?: ProjectionOptions): PromiseResult<DynamoAuditLog | null>
   fetchByStatus(status: string, options?: FetchByStatusOptions): PromiseResult<DynamoAuditLog[]>
   fetchMany(options?: FetchManyOptions): PromiseResult<DynamoAuditLog[]>
   fetchOne(messageId: string, options?: FetchOneOptions): PromiseResult<DynamoAuditLog | undefined>

--- a/src/audit-log-api/handlers/getMessages.test.ts
+++ b/src/audit-log-api/handlers/getMessages.test.ts
@@ -141,3 +141,37 @@ test("should return a single message when the externalCorrelationId is given and
   expect(actualMessage.caseId).toBe(log1.caseId)
   expect(actualMessage.receivedDate).toBe(log1.receivedDate)
 })
+
+test("should return an empty array when messageHash is specified and no messages are found", async () => {
+  mockCreateMessageFetcher.mockReturnValue(createDummyMessageFetcher(null))
+
+  const event = createEvent(undefined, { messageHash: "SomeMessageHash" })
+  const messages = await getMessages(event)
+
+  const actualResponse = <APIGatewayProxyResult>messages
+  expect(actualResponse.statusCode).toBe(HttpStatusCode.notFound)
+
+  const actualMessages: OutputApiAuditLog[] = JSON.parse(actualResponse.body)
+  expect(actualMessages).toBeDefined()
+  expect(actualMessages).toHaveLength(0)
+})
+
+test("should return a single message when the messageHash is given and a match is found", async () => {
+  mockCreateMessageFetcher.mockReturnValue(createDummyMessageFetcher(log1))
+
+  const event = createEvent(undefined, { messageHash: "SomeMessageHash" })
+  const messages = await getMessages(event)
+
+  const actualResponse = <APIGatewayProxyResult>messages
+  expect(actualResponse.statusCode).toBe(HttpStatusCode.ok)
+
+  const actualMessages: OutputApiAuditLog[] = JSON.parse(actualResponse.body)
+  expect(actualMessages).toBeDefined()
+  expect(actualMessages).toHaveLength(1)
+
+  const actualMessage = actualMessages[0]
+  expect(actualMessage.messageId).toBe(log1.messageId)
+  expect(actualMessage.externalCorrelationId).toBe(log1.externalCorrelationId)
+  expect(actualMessage.caseId).toBe(log1.caseId)
+  expect(actualMessage.receivedDate).toBe(log1.receivedDate)
+})

--- a/src/audit-log-api/use-cases/FetchByHash.test.ts
+++ b/src/audit-log-api/use-cases/FetchByHash.test.ts
@@ -1,0 +1,31 @@
+import { mockDynamoAuditLog } from "src/shared/testing"
+import type { DynamoAuditLog } from "src/shared/types"
+import { isError } from "src/shared/types"
+import { FakeAuditLogDynamoGateway } from "../test"
+import FetchByHash from "./FetchByHash"
+
+const gateway = new FakeAuditLogDynamoGateway()
+
+it("should return one message when messageHash exists", async () => {
+  const expectedMessage = mockDynamoAuditLog()
+  gateway.reset([expectedMessage])
+
+  const messageFetcher = new FetchByHash(gateway, expectedMessage.messageHash)
+  const result = await messageFetcher.fetch()
+
+  expect(isError(result)).toBe(false)
+
+  const actualMessage = <DynamoAuditLog>result
+  expect(actualMessage.messageId).toBe(expectedMessage.messageId)
+})
+
+it("should return an error when fetchOne fails", async () => {
+  const expectedError = new Error("Results not found")
+  gateway.shouldReturnError(expectedError)
+
+  const messageFetcher = new FetchByHash(gateway, "Invalid hash")
+  const result = await messageFetcher.fetch()
+
+  expect(isError(result)).toBe(true)
+  expect(result).toBe(expectedError)
+})

--- a/src/audit-log-api/use-cases/FetchByHash.ts
+++ b/src/audit-log-api/use-cases/FetchByHash.ts
@@ -1,0 +1,23 @@
+import type { OutputApiAuditLog, PromiseResult } from "src/shared/types"
+import { isError } from "src/shared/types"
+import type { AuditLogDynamoGatewayInterface } from "../gateways/dynamo"
+import type { ProjectionOptions } from "../types/queryParams"
+import convertDynamoAuditLogToOutputApi from "../utils/convertDynamoAuditLogToOutputApi"
+import type MessageFetcher from "./MessageFetcher"
+
+export default class FetchByHash implements MessageFetcher {
+  constructor(
+    private readonly gateway: AuditLogDynamoGatewayInterface,
+    private messageId: string,
+    private readonly options?: ProjectionOptions
+  ) {}
+
+  async fetch(): PromiseResult<OutputApiAuditLog | undefined> {
+    const record = await this.gateway.fetchByHash(this.messageId, this.options)
+    if (isError(record) || typeof record === "undefined" || record === null) {
+      return record ?? undefined
+    }
+
+    return convertDynamoAuditLogToOutputApi(record)
+  }
+}

--- a/src/audit-log-api/use-cases/createMessageFetcher.test.ts
+++ b/src/audit-log-api/use-cases/createMessageFetcher.test.ts
@@ -3,6 +3,7 @@ import { FakeAuditLogDynamoGateway } from "../test"
 import createMessageFetcher from "./createMessageFetcher"
 import FetchAll from "./FetchAll"
 import FetchByExternalCorrelationId from "./FetchByExternalCorrelationId"
+import FetchByHash from "./FetchByHash"
 import FetchById from "./FetchById"
 import FetchByStatus from "./FetchByStatus"
 
@@ -27,6 +28,18 @@ describe("createMessageFetcher()", () => {
     const messageFetcher = createMessageFetcher(event, gateway)
 
     expect(messageFetcher instanceof FetchById).toBe(true)
+  })
+
+  it("should return FetchByHash when messageHash exists in the query", () => {
+    const event = <APIGatewayProxyEvent>(<unknown>{
+      queryStringParameters: {
+        messageHash: "1"
+      }
+    })
+
+    const messageFetcher = createMessageFetcher(event, gateway)
+
+    expect(messageFetcher instanceof FetchByHash).toBe(true)
   })
 
   it("should return FetchByExternalCorrelationId when externalCorrelationId exists in the query string", () => {

--- a/src/audit-log-api/use-cases/createMessageFetcher.ts
+++ b/src/audit-log-api/use-cases/createMessageFetcher.ts
@@ -3,6 +3,7 @@ import type { AuditLogDynamoGatewayInterface } from "../gateways/dynamo"
 import FetchAll from "./FetchAll"
 import FetchAutomationReport from "./FetchAutomationReport"
 import FetchByExternalCorrelationId from "./FetchByExternalCorrelationId"
+import FetchByHash from "./FetchByHash"
 import FetchById from "./FetchById"
 import FetchByStatus from "./FetchByStatus"
 import FetchTopExceptionsReport from "./FetchTopExceptionsReport"
@@ -14,6 +15,7 @@ const createMessageFetcher = (
   auditLogGateway: AuditLogDynamoGatewayInterface
 ): MessageFetcher | Error => {
   const messageId = event.pathParameters?.messageId
+  const messageHash = event.queryStringParameters?.messageHash
   const externalCorrelationId = event.queryStringParameters?.externalCorrelationId
   const status = event.queryStringParameters?.status
   const lastMessageId = event.queryStringParameters?.lastMessageId
@@ -53,6 +55,10 @@ const createMessageFetcher = (
 
   if (messageId) {
     return new FetchById(auditLogGateway, messageId, projection)
+  }
+
+  if (messageHash) {
+    return new FetchByHash(auditLogGateway, messageHash, projection)
   }
 
   if (externalCorrelationId) {


### PR DESCRIPTION
This PR updates `/messages` endpoint to filter message by message hash. e.g. `/messages?messageHash=abc`