### PR TITLE
Throw error when message id or user id is missing

### DIFF
--- a/src/event-handler/e2e/e2e.test.ts
+++ b/src/event-handler/e2e/e2e.test.ts
@@ -171,7 +171,7 @@ test("Event with only user should be stored in dynamodb", async () => {
   expect(events[0].user).toBe("supervisor")
 })
 
-test("Event with no MesageId and User should not fail to be processed by the audit logger", async () => {
+test("Event with no MesageId and User should fail to be processed by the audit logger", async () => {
   const rawMessage = fs.readFileSync(`events/no-messageid-and-user.xml`).toString()
   const messageData = encodeBase64(rawMessage.replace("{MESSAGE_ID}", uuid()))
 
@@ -199,7 +199,7 @@ test("Event with no MesageId and User should not fail to be processed by the aud
   const objectKey = s3Objects.map((s3Object) => s3Object.Key)[0]
   const eventHandlerResult = await eventHandlerSimulator.start(objectKey!, uuid()).catch((error) => error)
 
-  expect(eventHandlerResult).toNotBeError()
+  expect((eventHandlerResult as Error).message).toContain("No messageId or userName:")
 })
 
 test("Event should fail the validation when S3 object does not exist", async () => {

--- a/src/event-handler/use-cases/CreateEventUseCase.test.ts
+++ b/src/event-handler/use-cases/CreateEventUseCase.test.ts
@@ -33,12 +33,11 @@ describe("CreateEventUseCase", () => {
     expect(mockedCreateUserEvent).toHaveBeenCalledTimes(1)
   })
 
-  it("should be successful when messageId and user are not provided", async () => {
-    const result = await useCase.execute("", {} as ApiAuditLogEvent)
-
-    expect(result).toBeUndefined()
-    expect(mockedCreateEvent).not.toHaveBeenCalled()
-    expect(mockedCreateUserEvent).not.toHaveBeenCalled()
+  it("should throw an error when messageId and user are not provided", async () => {
+    const invalidMessage = { category: "information" } as ApiAuditLogEvent
+    await expect(async () => {
+      await useCase.execute("", invalidMessage)
+    }).rejects.toThrow(`No messageId or userName: ${JSON.stringify(invalidMessage)}`)
   })
 
   it("should fail when audit log API fails to create event when messageId has value", async () => {

--- a/src/event-handler/use-cases/CreateEventUseCase.ts
+++ b/src/event-handler/use-cases/CreateEventUseCase.ts
@@ -1,4 +1,3 @@
-import { logger } from "src/shared"
 import type { ApiAuditLogEvent, ApiClient, PromiseResult } from "src/shared/types"
 
 export default class {
@@ -14,7 +13,6 @@ export default class {
       return this.api.createUserEvent(String(userName), event)
     }
 
-    logger.info(`No messageId or userName: ${JSON.stringify(event)}`)
-    return Promise.resolve(undefined)
+    throw Error(`No messageId or userName: ${JSON.stringify(event)}`)
   }
 }


### PR DESCRIPTION
This will cause the lambda to fail, so we know when audit log messages are not created.