### PR TITLE
Use nodejs-20-2023 for the api and event handler images

### DIFF
--- a/src/audit-log-api/Dockerfile
+++ b/src/audit-log-api/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE="nodejs"
+ARG BUILD_IMAGE="nodejs-20-2023"
 FROM ${BUILD_IMAGE}
 
 WORKDIR /server

--- a/src/event-handler/Dockerfile
+++ b/src/event-handler/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_IMAGE="nodejs"
+ARG BUILD_IMAGE="nodejs-20-2023"
 FROM ${BUILD_IMAGE}
 
 WORKDIR /server


### PR DESCRIPTION
Update audit log API and event handler docker file to use `nodejs-20-2023` as base image.