### PR TITLE
Add exception code summarise record

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,5 @@
 node_modules
 build
 dist
-storybook-static
-cypress.config.ts
 build.js
-scripts/*
+scripts/**/*

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "wait-for-api": "wait-on tcp:3010"
   },
   "lint-staged": {
-    "*.{js,ts}": "eslint --cache --fix --max-warnings 0 --ignore-pattern !.ncurc.js"
+    "src/**/*.{js,ts}": "eslint --cache --fix --max-warnings 0 --ignore-pattern !.ncurc.js"
   },
   "dependencies": {
     "aws-lambda": "^1.0.7",

--- a/scripts/utils/summarise-record.ts
+++ b/scripts/utils/summarise-record.ts
@@ -49,6 +49,15 @@ const getTriggersFromAttributes = (attributes: AuditLogEventAttributes): string[
   }, [])
 }
 
+const getExceptionsFromAttributes = (attributes: AuditLogEventAttributes): string[] => {
+  return Object.entries(attributes).reduce((acc: string[], [key, value]) => {
+    if (key.match(/Exception Type/)) {
+      acc.push(value.toString())
+    }
+    return acc
+  }, [])
+}
+
 const formatEvent = (event: DynamoAuditLogEvent): string => {
   const output: string[] = []
   output.push(`${event.timestamp} - ${event.eventType}`)
@@ -61,6 +70,9 @@ const formatEvent = (event: DynamoAuditLogEvent): string => {
   if (event.eventCode === "triggers.resolved" && event.attributes) {
     output.push(`${" ".repeat(27)}${getTriggersFromAttributes(event.attributes).sort().join(", ")}`)
     output.push(`${" ".repeat(27)}User: ${event.user}`)
+  }
+  if (event.eventCode === "exceptions.generated" && event.attributes) {
+    output.push(`${" ".repeat(27)}${getExceptionsFromAttributes(event.attributes).sort().join(", ")}`)
   }
   return output.join("\n")
 }


### PR DESCRIPTION
Whilst pairing yesterday on a support ticket @chubberlisk pointed out that we did not display the exception code when we generate a summary for a message that had been played through Bichard. 

This now displays the exception code

Before:
![Screenshot 2024-08-13 at 17 56 35](https://github.com/user-attachments/assets/9877a3a2-fc49-4f7b-b44b-e4f1adb07274)

After:
![Screenshot 2024-08-14 at 11 32 54](https://github.com/user-attachments/assets/7447cd17-f0d5-4be5-9c61-c7322eb873f5)

