### PR TITLE
BICAWS7-4225 Add Dependabot Ignore List

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,20 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@typescript-eslint/eslint-plugin"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "@typescript-eslint/eslint-plugin-jest"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "@typescript-eslint/parser"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "eslint"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "serverless"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "serverless-offline"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "uuid"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "zod"
+        update-types: [ "version-update:semver-major" ]

--- a/.ncurc.js
+++ b/.ncurc.js
@@ -5,7 +5,7 @@
 */
 /*
   Minor:
-  - severless [28/04/24 - major bump breaks dependencies]
+  - serverless [28/04/24 - major bump breaks dependencies]
   - serverless-offline [28/04/24 - major bump breaks dependencies]
 */
 const minor = [


### PR DESCRIPTION
Several packages are pinned in our `ncurc.js` pending a major update (BICAWS7-4225), but Dependabot is continuing to open PRs for vulnerabilities in these dependencies

An ignore list has been added to restrict these packages to minor/patch updates until the major update can be completed