### PR TITLE
Use handler exports instead of default exports 

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -286,13 +286,13 @@ resources:
 
 functions:
   getMessages:
-    handler: src/audit-log-api/handlers/getMessages.default
+    handler: src/audit-log-api/handlers/getMessages.handler
     events:
       - httpApi:
           path: /messages
           method: get
   getMessage:
-    handler: src/audit-log-api/handlers/getMessages.default
+    handler: src/audit-log-api/handlers/getMessages.handler
     events:
       - httpApi:
           path: /messages/{messageId}

--- a/src/audit-log-api/handlers/getMessages.test.ts
+++ b/src/audit-log-api/handlers/getMessages.test.ts
@@ -12,7 +12,7 @@ import type { DynamoAuditLog, OutputApiAuditLog, Result } from "src/shared/types
 import "../testConfig"
 import { createMessageFetcher } from "../use-cases"
 import type MessageFetcher from "../use-cases/MessageFetcher"
-import getMessages from "./getMessages"
+import { handler as getMessages } from "./getMessages"
 
 const mockCreateMessageFetcher = createMessageFetcher as jest.MockedFunction<typeof createMessageFetcher>
 

--- a/src/audit-log-api/handlers/getMessages.ts
+++ b/src/audit-log-api/handlers/getMessages.ts
@@ -9,7 +9,7 @@ import { createJsonApiResult } from "../utils"
 const auditLogConfig = createAuditLogDynamoDbConfig()
 const auditLogGateway = new AuditLogDynamoGateway(auditLogConfig)
 
-export default async function getMessages(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
+export const handler = async function getMessages(event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> {
   const messageFetcher = createMessageFetcher(event, auditLogGateway)
 
   if (isError(messageFetcher)) {

--- a/src/audit-log-api/test-server.ts
+++ b/src/audit-log-api/test-server.ts
@@ -5,7 +5,7 @@ import express from "express"
 import createAuditLog from "./handlers/createAuditLog"
 import createAuditLogEvents from "./handlers/createAuditLogEvents"
 import createAuditLogUserEvents from "./handlers/createAuditLogUserEvents"
-import getMessages from "./handlers/getMessages"
+import { handler as getMessages } from "./handlers/getMessages"
 import retryMessage from "./handlers/retryMessage"
 import sanitiseMessage from "./handlers/sanitiseMessage"
 


### PR DESCRIPTION
Node.js 24 seems to not be playing well with default exports so changed to explicit named exports